### PR TITLE
Allow both old and new define-ibuffer-op macro references to coexist

### DIFF
--- a/README.org
+++ b/README.org
@@ -1186,6 +1186,29 @@ remain in force until they are saved if this policy is set to t.
     (bufferlo-anywhere-mode))
 #+end_src
 
+*** CRM prompt enhancement
+
+Bufferlo uses ~completing-read-multiple~ for the prompts where you can
+specify more than one input selection; e.g., when opening multiple
+bookmarks at once using ~bufferlo-bookmarks-load-interactive~. Emacs
+31 will be getting a proper CRM prompt that displays the CRM separator
+character as a reminder hint. Note: The default separator is a comma.
+
+Per https://github.com/minad/vertico#completing-read-multiple from the
+author of the Emacs CRM patch, we recommend adding the following
+snippet to your Emacs configuration.
+
+#+begin_src emacs-lisp
+;; Prompt indicator for `completing-read-multiple'.
+(when (< emacs-major-version 31)
+  (advice-add #'completing-read-multiple :filter-args
+              (lambda (args)
+                (cons (format "[CRM%s] %s"
+                              (string-replace "[ \t]*" "" crm-separator)
+                              (car args))
+                      (cdr args))))))
+#+end_src
+
 * Alternatives
 
 ** desktop.el

--- a/README.org
+++ b/README.org
@@ -637,6 +637,23 @@ bookmark set is loaded.
   (setq bufferlo-set-restore-tabs-reuse-init-frame nil) ; always make new frames
 #+end_src
 
+*** Bookmark handler hooks
+
+You can add your own functions to the following abnormal hooks to be
+called upon successful loading of tab, frame, and set bookmarks. See
+the docstrings for each function for its calling conventions.
+
+Example: You could use a tab handler function to set the tab-bar group
+for each loaded tab to its source bookmark name. While tab-bar does
+have ~tab-bar-tab-post-open-functions~, the bookmark context will not
+be available when those functions are called.
+
+#+begin_src emacs-lisp
+  (add-hook 'bufferlo-bookmark-tab-handler-functions #'tab-bookmark-fun)
+  (add-hook 'bufferlo-bookmark-frame-handler-functions #'frame-bookmark-fun)
+  (add-hook 'bufferlo-bookmark-set-handler-functions #'set-bookmark-fun)
+#+end_src
+
 *** Frame geometry options
 
 Bufferlo provides wrappers around Emacs frame functions to provide

--- a/README.org
+++ b/README.org
@@ -56,7 +56,7 @@ Note: Code examples use ~setq~ to customize options. You may also use
 ~M-x customize-group bufferlo~. Emacs 29 introduced ~setopt~ which
 works correctly in the presence of ~defcustom~ setters. Currently the
 only bufferlo option with such a setter is
-~bufferlo-bookmarks-auto-save-idle-interval~ so be sure to set that
+~bufferlo-bookmarks-auto-save-interval~ so be sure to set that
 interval timer in advance of enabling ~bufferlo-mode~.
 
 Note: Many bufferlo commands have short-hand aliases to accommodate
@@ -407,8 +407,8 @@ To set the automatic save timer, set the number of whole integer
 seconds between saves that you prefer, or 0, the default, to disable
 the timer:
 #+begin_src emacs-lisp
-  (setq bufferlo-bookmarks-auto-save-idle-interval 120) ; do this in advance of enabling `bufferlo-mode'
-  (setopt bufferlo-bookmarks-auto-save-idle-interval 120) ; or use setopt, to invoke the custom setter
+  (setq bufferlo-bookmarks-auto-save-interval 120) ; do this in advance of enabling `bufferlo-mode'
+  (setopt bufferlo-bookmarks-auto-save-interval 120) ; or use setopt, to invoke the custom setter
 #+end_src
 
 By default, bufferlo will save all active bookmarks. To select the
@@ -1106,7 +1106,7 @@ remain in force until they are saved if this policy is set to t.
     (setq bufferlo-bookmarks-save-at-emacs-exit-policy 'all)
     (setq bufferlo-bookmarks-load-at-emacs-startup 'pred)
     (setq bufferlo-bookmarks-load-at-emacs-startup-tabs-make-frame nil)
-    (setopt bufferlo-bookmarks-auto-save-idle-interval (* 60 5)) ; 5 minutes
+    (setopt bufferlo-bookmarks-auto-save-interval (* 60 5)) ; 5 minutes
     (setq bufferlo-bookmarks-auto-save-messages 'saved)
     (setq bufferlo-set-restore-geometry-policy 'all)
     (setq bufferlo-set-restore-tabs-reuse-init-frame 'reuse) ; nil 'reuse 'reuse-reset-geometry

--- a/README.org
+++ b/README.org
@@ -747,8 +747,8 @@ references to your files and buffers. Many Emacs modes support Emacs
 bookmarks and can be saved and recalled including ~eshell~ and
 ~magit-status~ buffers. The state of non-bookmarkable buffers is not
 saved. However, during bookmark saving, they are included in the
-bookmark record. At this time, Emacs does not support ~*shell*~ buffer
-bookmarks.
+bookmark record. Emacs 31 has support for ~shell-mode~ local and
+remote buffer bookmarks.
 
 Restoring bookmarks correctly handles renamed buffers with unchanged
 file association (e.g., when Emacs had to "uniquify" buffer names).
@@ -1130,6 +1130,8 @@ remain in force until they are saved if this policy is set to t.
     (setq bufferlo-frameset-restore-geometry 'bufferlo)
     (setq bufferlo-frame-geometry-function #'bufferlo-frame-geometry-default)
     (setq bufferlo-frame-sleep-for 0.3)
+
+    (setq bookmark-bmenu-type-column-width 12) ; supported in Emacs 31 (innocuous on earlier versions)
 
     (setq bufferlo-bookmark-buffers-exclude-filters
           (list

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2856,7 +2856,7 @@ message."
     (setq tabsets
           (mapcar (lambda (group)
                     (let ((tbm-frame (car group))
-                          (tbm-names (mapcar #'car (cdr group))))
+                          (tbm-names (nreverse (mapcar #'car (cdr group)))))
                       `((bufferlo--frame-geometry
                          . ,(funcall bufferlo-frame-geometry-function tbm-frame))
                         (bufferlo--tbms . ,tbm-names))))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1918,45 +1918,19 @@ The parameters OTHER-WINDOW-P NOSELECT SHRINK are passed to `ibuffer'."
     (ibuffer other-window-p name '((bufferlo-orphan-buffers . nil))
              noselect shrink)))
 
-(eval-when-compile
-  (if (< emacs-major-version 31)
-      (define-ibuffer-op ibuffer-do-bufferlo-remove ()
-        "Remove marked buffers from bufferlo's local buffer list."
-        (
-         :active-opstring "remove from bufferlo locals" ; prompt
-         :opstring "removed from bufferlo locals:" ; success
-         :modifier-p t
-         :dangerous t
-         :complex t
-         :after (ibuffer-update nil t)
-         )
-        (when bufferlo-mode
-          (bufferlo-remove buf)
-          t))
-
-    (defun bufferlo--ibuffer-do-bufferlo-remove-prompt (op)
-      "`ibuffer' prompt helper for OP."
-      (let ((bookmark-name (bufferlo--current-bookmark-name)))
-        (format "%s from %slocals:" op
-                (if bookmark-name
-                    (format "bufferlo bookmark \"%s\" " bookmark-name)
-                  ""))))
-
-    (define-ibuffer-op ibuffer-do-bufferlo-remove ()
-      "Remove marked buffers from bufferlo\'s local buffer list."
-      (
-       :active-opstring (lambda ()
-                        (bufferlo--ibuffer-do-bufferlo-remove-prompt "remove"))
-       :opstring (lambda ()
-                 (bufferlo--ibuffer-do-bufferlo-remove-prompt "removed"))
-       :modifier-p t
-       :dangerous t
-       :complex t
-       :after (ibuffer-update nil t)
-       )
-      (when bufferlo-mode
-        (bufferlo-remove buf)
-        t))))
+(define-ibuffer-op ibuffer-do-bufferlo-remove ()
+  "Remove marked buffers from bufferlo's local buffer list."
+  (
+   :active-opstring "remove from bufferlo locals" ; prompt
+   :opstring "removed from bufferlo locals:" ; success
+   :modifier-p t
+   :dangerous t
+   :complex t
+   :after (ibuffer-update nil t)
+   )
+  (when bufferlo-mode
+    (bufferlo-remove buf)
+    t))
 
 (when bufferlo-ibuffer-bind-keys
   (define-key ibuffer-mode-map "-" #'ibuffer-do-bufferlo-remove))
@@ -2132,7 +2106,7 @@ local buffer list to use.  If it is nil, the current frame is used."
     (seq-union buffers-excl buffers-incl)))
 
 (defun bufferlo--bookmark-get-for-buffers-in-tab (buffers)
-  "Get bookmarks for all buffers of the selected tab in FRAME."
+  "Get bookmarks for all BUFFERS of the selected tab in FRAME."
   (seq-filter #'identity
               (mapcar #'bufferlo--bookmark-get-for-buffer
                       buffers)))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -3179,7 +3179,7 @@ This reuses the current tab even if
   (bufferlo--warn)
   (if-let* ((bm (alist-get 'bufferlo-bookmark-tab-name
                            (cdr (bufferlo--current-tab)))))
-      ;; On reload, always resue the existing tab (don't make a new one)
+      ;; On reload, always reuse the existing tab (don't make a new one)
       (let ((bufferlo-bookmark-tab-replace-policy 'replace)
             ;; The bookmark is detected as a duplicate bookmark, allow it here
             (bufferlo-bookmark-tab-duplicate-policy 'allow))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1937,19 +1937,46 @@ The parameters OTHER-WINDOW-P NOSELECT SHRINK are passed to `ibuffer'."
     (ibuffer other-window-p name '((bufferlo-orphan-buffers . nil))
              noselect shrink)))
 
-(define-ibuffer-op ibuffer-do-bufferlo-remove ()
-  "Remove marked buffers from bufferlo's local buffer list."
-  (
-   :active-opstring "remove from bufferlo locals" ; prompt
-   :opstring "removed from bufferlo locals:" ; success
-   :modifier-p t
-   :dangerous t
-   :complex t
-   :after (ibuffer-update nil t)
-   )
-  (when bufferlo-mode
-    (bufferlo-remove buf)
-    t))
+;; Below allows both old and new define-ibuffer-op macros to coexist.
+(defmacro bufferlo--ibuffer-do-wrapper ()
+  (if (< emacs-major-version 31)
+      '(define-ibuffer-op ibuffer-do-bufferlo-remove ()
+         "Remove marked buffers from bufferlo's local buffer list."
+         (
+          :active-opstring "remove from bufferlo locals"
+          :opstring "removed from bufferlo locals:"
+          :modifier-p t
+          :dangerous t
+          :complex t
+          :after (ibuffer-update nil t)
+          )
+         (when bufferlo-mode
+           (bufferlo-remove buf)
+           t))
+
+    '(defun bufferlo--ibuffer-do-bufferlo-remove-prompt (op)
+       "`ibuffer' prompt helper for OP."
+       (let ((bookmark-name (bufferlo--current-bookmark-name)))
+         (format "%s from %slocals:" op
+                 (if bookmark-name
+                     (format "bufferlo bookmark \"%s\" " bookmark-name)
+                   ""))))
+
+    '(define-ibuffer-op ibuffer-do-bufferlo-remove ()
+       "Remove marked buffers from bufferlo's local buffer list."
+       (
+        :active-opstring (lambda () (bufferlo--ibuffer-do-bufferlo-remove-prompt "remove"))
+        :opstring (lambda () (bufferlo--ibuffer-do-bufferlo-remove-prompt "removed"))
+        :modifier-p t
+        :dangerous t
+        :complex t
+        :after (ibuffer-update nil t)
+        )
+       (when bufferlo-mode
+         (bufferlo-remove buf)
+         t))
+    ))
+(bufferlo--ibuffer-do-wrapper)
 
 (when bufferlo-ibuffer-bind-keys
   (define-key ibuffer-mode-map "-" #'ibuffer-do-bufferlo-remove))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -393,12 +393,11 @@ advance that prevent duplicate frame and tab bookmarks."
 (defcustom bufferlo-bookmarks-save-predicate-functions
   (list #'bufferlo-bookmarks-save-all-p)
   "Functions to filter active bufferlo bookmarks to save.
-These are applied when
-`bufferlo-bookmarks-auto-save-idle-interval' is > 0, or manually
-via `bufferlo-bookmarks-save'.  Functions are passed the bufferlo
-bookmark name and invoked until the first positive result.  Set to
-`#'bufferlo-bookmarks-save-all-p' to save all bookmarks or
-provide your own predicates (note: be sure to remove
+These are applied when `bufferlo-bookmarks-auto-save-interval' is > 0,
+or manually via `bufferlo-bookmarks-save'.  Functions are passed the
+bufferlo bookmark name and invoked until the first positive result.  Set
+to `#'bufferlo-bookmarks-save-all-p' to save all bookmarks or provide
+your own predicates (note: be sure to remove
 `#'bufferlo-bookmarks-save-all-p' from the list)."
   :type 'hook)
 
@@ -523,7 +522,7 @@ frame bookmark is a collection of tab bookmarks."
 
 (defvar bufferlo--bookmarks-auto-save-timer nil
   "Timer to save bufferlo bookmarks.
-This is controlled by `bufferlo-bookmarks-auto-save-idle-interval'.")
+This is controlled by `bufferlo-bookmarks-auto-save-interval'.")
 
 (defun bufferlo--bookmarks-auto-save-timer-maybe-cancel ()
   "Cancel and clear the bufferlo bookmark auto-save timer, if set."
@@ -531,19 +530,20 @@ This is controlled by `bufferlo-bookmarks-auto-save-idle-interval'.")
     (cancel-timer bufferlo--bookmarks-auto-save-timer))
   (setq bufferlo--bookmarks-auto-save-timer nil))
 
-(defvar bufferlo-bookmarks-auto-save-idle-interval) ; byte compiler
+(defvar bufferlo-bookmarks-auto-save-interval) ; byte compiler
 (defun bufferlo--bookmarks-auto-save-timer-maybe-start ()
   "Start the bufferlo auto-save bookmarks timer, if needed."
   (bufferlo--bookmarks-auto-save-timer-maybe-cancel)
-  (when (> bufferlo-bookmarks-auto-save-idle-interval 0)
+  (when (and (integerp bufferlo-bookmarks-auto-save-interval)
+             (> bufferlo-bookmarks-auto-save-interval 0))
     (setq bufferlo--bookmarks-auto-save-timer
-          (run-with-idle-timer
-           bufferlo-bookmarks-auto-save-idle-interval
-           bufferlo-bookmarks-auto-save-idle-interval
+          (run-with-timer
+           bufferlo-bookmarks-auto-save-interval
+           bufferlo-bookmarks-auto-save-interval
            #'bufferlo-bookmarks-save))))
 
-(defcustom bufferlo-bookmarks-auto-save-idle-interval 0
-  "Save bufferlo bookmarks when Emacs has been idle this many seconds.
+(defcustom bufferlo-bookmarks-auto-save-interval 0
+  "Save bufferlo bookmarks every interval of this many seconds.
 Set to 0 to disable the timer.  Units are whole integer seconds."
   :type 'natnum
   :set (lambda (sym val)
@@ -3422,23 +3422,22 @@ Specify NO-MESSAGE to inhibit the bookmark save status message."
 
 (defun bufferlo-bookmarks-save (&optional all)
   "Save active bufferlo bookmarks.
-This is invoked via an optional idle timer which runs according
-to `bufferlo-bookmarks-auto-save-idle-interval', or and is
-optionally invoked at Emacs exit.
+This is invoked via an optional timer which runs according to
+`bufferlo-bookmarks-auto-save-interval', or and is optionally invoked at
+Emacs exit.
 
-You may invoke this manually at any time to save active
-bookmarks; however, doing so does not reset the save interval
-timer.
+You may invoke this manually at any time to save active bookmarks;
+however, doing so does not reset the save interval timer.
 
 Each bookmark is filtered according to
 `bufferlo-bookmarks-save-predicate-functions'.
 
-Specify ALL to ignore the predicates and save every active
-bufferlo bookmark or use a prefix argument across ALL frames,
-overriding `bufferlo-bookmarks-save-frame-policy'.
+Specify ALL to ignore the predicates and save every active bufferlo
+bookmark or use a prefix argument across ALL frames, overriding
+`bufferlo-bookmarks-save-frame-policy'.
 
-Note: if there are duplicate active bufferlo bookmarks, the last
-one to be saved will take precedence.
+Note: If there are duplicate active bufferlo bookmarks, the last one to
+be saved will take precedence.
 
 Duplicate bookmarks are handled according to
 `bufferlo-bookmarks-save-duplicates-policy'."

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2336,6 +2336,7 @@ this bookmark is embedded in a frame bookmark."
 
 ;; We use a short name here as bookmark-bmenu-list hard codes width of 8 chars
 (put #'bufferlo--bookmark-tab-handler 'bookmark-handler-type "B-Tab")
+(put #'bufferlo--bookmark-tab-handler 'bookmark-inhibit 'insert)
 
 (defun bufferlo--bookmark-frame-make (&optional frame)
   "Make a bufferlo frame bookmark.
@@ -2506,6 +2507,7 @@ the message after successfully restoring the bookmark."
 
 ;; We use a short name here as bookmark-bmenu-list hard codes width of 8 chars
 (put #'bufferlo--bookmark-frame-handler 'bookmark-handler-type "B-Frame")
+(put #'bufferlo--bookmark-frame-handler 'bookmark-inhibit 'insert)
 
 (defun bufferlo--bookmark-set-location (bookmark-name-or-record &optional location)
   "Set the location of BOOKMARK-NAME-OR-RECORD to LOCATION or \\=\"\", if nil."
@@ -2843,6 +2845,7 @@ the message after successfully restoring the bookmark."
 
 ;; We use a short name here as bookmark-bmenu-list hard codes width of 8 chars
 (put #'bufferlo--bookmark-set-handler 'bookmark-handler-type "B-Set")
+(put #'bufferlo--bookmark-set-handler 'bookmark-inhibit 'insert)
 
 (defun bufferlo--set-save (bookmark-name active-bookmark-names active-bookmarks &optional no-overwrite)
   "Save a bufferlo bookmark set for the specified active bookmarks.

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2310,7 +2310,8 @@ this bookmark is embedded in a frame bookmark."
             ('replace)
             ('new
              (unless (consp current-prefix-arg) ; user new tab suppression
-               (tab-bar-new-tab-to)))))
+               (let ((tab-bar-new-tab-choice t))
+                 (tab-bar-new-tab-to))))))
 
         ;; Handle an independent tab bookmark inside a frame bookmark
         (when (and bookmark-name

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2131,20 +2131,22 @@ local buffer list to use.  If it is nil, the current frame is used."
                         buffers)))
     (seq-union buffers-excl buffers-incl)))
 
-(defun bufferlo--bookmark-get-for-buffers-in-tab (frame)
+(defun bufferlo--bookmark-get-for-buffers-in-tab (buffers)
   "Get bookmarks for all buffers of the selected tab in FRAME."
-  (with-selected-frame (or frame (selected-frame))
-    (seq-filter #'identity
-                (mapcar #'bufferlo--bookmark-get-for-buffer
-                        (bufferlo--bookmark-filter-buffers frame)))))
+  (seq-filter #'identity
+              (mapcar #'bufferlo--bookmark-get-for-buffer
+                      buffers)))
 
 (defun bufferlo--bookmark-tab-make (&optional frame)
   "Get the bufferlo tab bookmark for the current tab in FRAME.
 FRAME specifies the frame; the default value of nil selects the current frame."
-  `((buffer-bookmarks . ,(bufferlo--bookmark-get-for-buffers-in-tab frame))
-    (buffer-list . ,(mapcar #'buffer-name (bufferlo-buffer-list frame nil t)))
-    (window . ,(window-state-get (frame-root-window frame) 'writable))
-    (handler . ,#'bufferlo--bookmark-tab-handler)))
+  (let ((filtered-buffers
+         (with-selected-frame (or frame (selected-frame))
+           (bufferlo--bookmark-filter-buffers frame))))
+    `((buffer-bookmarks . ,(bufferlo--bookmark-get-for-buffers-in-tab filtered-buffers))
+      (buffer-list . ,(mapcar #'buffer-name filtered-buffers))
+      (window . ,(window-state-get (frame-root-window frame) 'writable))
+      (handler . ,#'bufferlo--bookmark-tab-handler))))
 
 (defun bufferlo--ws-replace-buffer-names (ws replace-alist)
   "Replace buffer names according to REPLACE-ALIST in the window state WS."

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -134,8 +134,8 @@ This policy applies to all bufferlo functions that entail killing buffers,
 e.g., `bufferlo-kill-buffers', `bufferlo-kill-orphan-buffers',
 `bufferlo-tab-close-kill-buffers', `bufferlo-delete-frame-kill-buffers'.
 
-This policy is useful when `shell-mode' or `eshell-mode' buffers
-are active in a bufferlo-controlled frame or tab.
+This policy is useful if `shell-mode' or `eshell-mode' buffers are
+active in a bufferlo-controlled frame or tab.
 
 nil means default Emacs behavior which may prompt.  This may have
 side effects.
@@ -159,7 +159,7 @@ without remorse including those with running processes such as
 
 (defcustom bufferlo-bookmark-inhibit-bookmark-point nil
   "If non-nil, inhibit point in bookmarks.
-This is useful when `save-place-mode' mode is enabled."
+This is useful if `save-place-mode' mode is enabled."
   :type 'boolean)
 
 (defcustom bufferlo-bookmark-buffers-exclude-filters nil
@@ -337,7 +337,7 @@ Note: \\='raise is considered \\='clear during `bookmark-set' loading."
                 (const :tag "Raise" raise)))
 
 (defcustom bufferlo-bookmark-tab-in-bookmarked-frame-policy 'prompt
-  "Control when a tab bookmark is loaded into an already-bookmarked frame.
+  "Control how a tab bookmark is loaded into an already-bookmarked frame.
 
 This also warns about setting a new frame bookmark on a frame
 that has tab bookmarks, and vice versa setting a tab bookmark on
@@ -351,7 +351,7 @@ bookmark.
 
 \\='allow will retain the tab bookmark to enable it to be saved
 or updated.  Note that the frame bookmark always supersedes the tab
-bookmark when the frame bookmark is saved."
+bookmark if the frame bookmark is saved."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
                 (const :tag "Clear (silently)" clear)
@@ -371,7 +371,7 @@ bookmarks.
 bookmark content for the same bookmark names.  A warning message
 indicates the names of duplicate bookmarks.
 
-Note: when using bufferlo's auto-save feature and to avoid
+Note: When using bufferlo's auto-save feature, and to avoid
 repeated prompts and warnings, it is best to choose policies in
 advance that prevent duplicate frame and tab bookmarks."
   :type '(radio (const :tag "Prompt" prompt)
@@ -1081,7 +1081,7 @@ buffers, see `bufferlo-hidden-buffers'."
 
 (defun bufferlo--clear-buffer-lists (&optional frame)
   "This is a workaround advice function to fix tab-bar's tab switching behavior.
-On `tab-bar-select-tab', when `wc-bl' or `wc-bbl' is nil, the function does not
+On `tab-bar-select-tab', if `wc-bl' or `wc-bbl' is nil, the function does not
 set the corresponding `buffer-list' / `buried-buffer-list' frame parameters.
 As a result the previous tab's values remain active.
 
@@ -1627,10 +1627,10 @@ The optional arguments KILLALL and INTERNAL-TOO are passed to
 
 (defun bufferlo-isolate-project (&optional file-buffers-only)
   "Isolate a project in the frame or tab.
-Remove all buffers that do not belong to the current project from
-the local buffer list.  When FILE-BUFFERS-ONLY is non-nil or the
-prefix argument is given, remove only buffers that visit a file.
-Buffers matching `bufferlo-include-buffer-filters' are not removed."
+Remove all buffers that do not belong to the current project from the
+local buffer list.  If FILE-BUFFERS-ONLY is non-nil or the prefix
+argument is given, remove only buffers that visit a file.  Buffers
+matching `bufferlo-include-buffer-filters' are not removed."
   (interactive "P")
   (bufferlo--warn)
   (if-let* ((curr-project (project-current))
@@ -1912,7 +1912,7 @@ for (almost) all functions.  Customize `bufferlo-anywhere-filter' and
 `bufferlo-anywhere-filter-type' to adapt the behavior.
 This minor mode requires `bufferlo-mode' to be enabled.
 You can use `bufferlo-anywhere-disable' to disable the local buffer list for
-the next command, when the mode is enabled."
+the next command, if the mode is enabled."
   :global t
   :require 'bufferlo
   :init-value nil
@@ -2167,7 +2167,7 @@ This functions throws :abort when the user quits."
 
 (defun bufferlo--bookmark-tab-get-replace-policy ()
   "Get the replace policy for tab bookmarks.
-Ask the user when `bufferlo-bookmark-tab-replace-policy' is set to \\='prompt.
+Prompt if `bufferlo-bookmark-tab-replace-policy' is set to \\='prompt.
 This functions throws :abort when the user quits."
   (if (not (eq bufferlo-bookmark-tab-replace-policy 'prompt))
       bufferlo-bookmark-tab-replace-policy
@@ -2184,7 +2184,7 @@ This functions throws :abort when the user quits."
 
 (defun bufferlo--bookmark-tab-get-clear-policy (mode)
   "Get the clear policy for tab bookmarks.
-Ask the user when `bufferlo-bookmark-tab-in-bookmarked-frame-policy' is
+Prompt if `bufferlo-bookmark-tab-in-bookmarked-frame-policy' is
 set to \\='prompt.  This functions throws :abort when the user quits.
 MODE is either \\='load, \\='save, or \\='save-frame, depending on the
 invoking action.  This functions throws :abort when the user quits."
@@ -2336,7 +2336,7 @@ FRAME specifies the frame; the default value of nil selects the current frame."
 
 (defun bufferlo--bookmark-frame-get-load-policy ()
   "Get the load policy for frame bookmarks.
-Ask the user when `bufferlo-bookmark-frame-load-policy' is set to \\='prompt.
+Prompt if `bufferlo-bookmark-frame-load-policy' is set to \\='prompt.
 This functions throws :abort when the user quits."
   (if (not (eq bufferlo-bookmark-frame-load-policy 'prompt))
       bufferlo-bookmark-frame-load-policy

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -75,7 +75,7 @@ Set to \\='ibuffer to show `ibuffer' only."
 (defcustom bufferlo-prefer-local-buffers t
   "Use the frame `buffer-predicate' to prefer local buffers.
 Without this option, buffers from across all frames are
-presented. This means that a local buffer will be preferred to be
+presented.  This means that a local buffer will be preferred to be
 displayed when the current buffer disappears (buried or killed).
 
 This also influences `next-buffer' and `previous-buffer'.
@@ -137,7 +137,7 @@ e.g., `bufferlo-kill-buffers', `bufferlo-kill-orphan-buffers',
 This policy is useful when `shell-mode' or `eshell-mode' buffers
 are active in a bufferlo-controlled frame or tab.
 
-nil means default Emacs behavior which may prompt. This may have
+nil means default Emacs behavior which may prompt.  This may have
 side effects.
 
 \\='retain-modified means bufferlo will leave modified buffers as
@@ -285,7 +285,7 @@ its bookmark.
 
 \\='raise will raise the frame with the existing bookmark.
 
-Note: \\='raise is considered \\='clear during bookmark-set loading."
+Note: \\='raise is considered \\='clear during `bookmark-set' loading."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
                 (const :tag "Clear (silently)" clear)
@@ -329,7 +329,7 @@ bookmark.
 \\='raise raises the first found existing tab bookmark and its
 frame.
 
-Note: \\='raise is considered \\='clear during bookmark-set loading."
+Note: \\='raise is considered \\='clear during `bookmark-set' loading."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
                 (const :tag "Clear (silently)" clear)
@@ -350,7 +350,7 @@ reified frame bookmark behavior.
 bookmark.
 
 \\='allow will retain the tab bookmark to enable it to be saved
-or updated. Note that the frame bookmark always supersedes the tab
+or updated.  Note that the frame bookmark always supersedes the tab
 bookmark when the frame bookmark is saved."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
@@ -364,11 +364,11 @@ bookmark when the frame bookmark is saved."
 
 \\='allow will save potentially differing content for the same
 bookmark name multiple times with the last-one-saved taking
-precedence. A warning message indicates the names of duplicate
+precedence.  A warning message indicates the names of duplicate
 bookmarks.
 
 \\='disallow prevents the potentially confusing of overwriting
-bookmark content for the same bookmark names. A warning message
+bookmark content for the same bookmark names.  A warning message
 indicates the names of duplicate bookmarks.
 
 Note: when using bufferlo's auto-save feature and to avoid
@@ -395,8 +395,8 @@ advance that prevent duplicate frame and tab bookmarks."
   "Functions to filter active bufferlo bookmarks to save.
 These are applied when
 `bufferlo-bookmarks-auto-save-idle-interval' is > 0, or manually
-via `bufferlo-bookmarks-save'. Functions are passed the bufferlo
-bookmark name and invoked until the first positive result. Set to
+via `bufferlo-bookmarks-save'.  Functions are passed the bufferlo
+bookmark name and invoked until the first positive result.  Set to
 `#'bufferlo-bookmarks-save-all-p' to save all bookmarks or
 provide your own predicates (note: be sure to remove
 `#'bufferlo-bookmarks-save-all-p' from the list)."
@@ -407,7 +407,7 @@ provide your own predicates (note: be sure to remove
 These are applied in `bufferlo-bookmarks-load' which might also
 be invoked at Emacs startup time using `window-setup-hook'.
 Functions are passed the bufferlo bookmark name and invoked until
-the first positive result. Set to
+the first positive result.  Set to
 `#'bufferlo-bookmarks-load-all-p' to load all bookmarks or
 provide your own predicates."
   :type 'hook)
@@ -544,7 +544,7 @@ This is controlled by `bufferlo-bookmarks-auto-save-idle-interval'.")
 
 (defcustom bufferlo-bookmarks-auto-save-idle-interval 0
   "Save bufferlo bookmarks when Emacs has been idle this many seconds.
-Set to 0 to disable the timer. Units are whole integer seconds."
+Set to 0 to disable the timer.  Units are whole integer seconds."
   :type 'natnum
   :set (lambda (sym val)
          (set-default sym val)
@@ -642,7 +642,7 @@ It defaults to `bufferlo-frameset-restore-parameters-default'."
 It defaults to `bufferlo-frame-geometry-default'.
 
 The function takes one parameter, FRAME, for which geometry is to
-be ascertained. See `bufferlo-frame-geometry-default' for
+be ascertained.  See `bufferlo-frame-geometry-default' for
 the returned alist form.
 
 Replace this function with your own if the default produces
@@ -662,7 +662,7 @@ suboptimal results for your platform."
 (defcustom bufferlo-frame-sleep-for 0
   "Window manager catch-up delay for changing frame parameters.
 Delay is specified in seconds using `sleep-for', which see.
-GTK/GNOME seems to need 0.3 seconds. YMMV.
+GTK/GNOME seems to need 0.3 seconds.  YMMV.
 No delay seems needed on macOS."
   :type 'natnum)
 
@@ -1298,8 +1298,8 @@ the advised functions."
 
 (defun bufferlo--clone-undelete-frame-advice (oldfn &rest args)
   "Activate the advice for `clone-frame' and `undelete-frame'.
-OLDFN is the original function.  ARGS is for compatibility with
-the advised functions. Honors `bufferlo-bookmark-frame-duplicate-policy'."
+OLDFN is the original function.  ARGS is for compatibility with the
+advised functions.  Honors `bufferlo-bookmark-frame-duplicate-policy'."
   (let ((bufferlo--desktop-advice-active t)
         (bufferlo--desktop-advice-active-force t))
     (apply oldfn args))
@@ -2723,8 +2723,8 @@ the message after successfully restoring the bookmark."
              bookmark-name))
 
     ;; Restore tabsets (tabsets can be nil despite readablep)
-    (when-let ((tabsets (car (read-from-string tabsets-str)))
-               (first-tab-frame t))
+    (when-let* ((tabsets (car (read-from-string tabsets-str)))
+                (first-tab-frame t))
       (bufferlo--with-temp-buffer
        (dolist (tab-group tabsets)
          (when (or (not first-tab-frame)
@@ -2758,7 +2758,7 @@ the message after successfully restoring the bookmark."
       (select-frame-set-input-focus (selected-frame)))
 
     ;; Restore framesets (framesets can be nil despite readablep)
-    (when-let ((frameset (car (read-from-string frameset-str))))
+    (when-let* ((frameset (car (read-from-string frameset-str))))
       (unless (frameset-valid-p frameset)
         (error "Bufferlo bookmark set %s: invalid frameset"
                bookmark-name))
@@ -2802,12 +2802,12 @@ Frame bookmarks are stored with their geometry for optional
 restoration.
 
 Tab bookmarks are stored in groups associated with their current
-frame. New frames will be created to hold tab bookmarks in the
-same grouping. Order may not be preserved. Tab frame geometry is
+frame.  New frames will be created to hold tab bookmarks in the
+same grouping.  Order may not be preserved.  Tab frame geometry is
 stored for optional restoration.
 
 If NO-OVERWRITE is non-nil, record the new bookmark without
-throwing away the old one. NO-MESSAGE inhibits the save status
+throwing away the old one.  NO-MESSAGE inhibits the save status
 message."
   (let* ((abms (seq-filter
                 (lambda (x) (member (car x) active-bookmark-names))
@@ -2912,7 +2912,7 @@ throwing away the old one."
      bufferlo--active-sets)))
 
 (defun bufferlo--set-get-constituents (bsets abms)
-  "Get the constituents of the given bookmark sets from the list of bookmarks.
+  "Get the constituents of the given `bookmark-sets' from the list of bookmarks.
 BSETS is a list of the requested sets and ABMS is a list of all bookmarks to
 consider (usually all active bookmarks)."
   (let* ((abm-names (mapcar #'car abms))
@@ -2926,7 +2926,7 @@ consider (usually all active bookmarks)."
     (seq-uniq abm-names)))
 
 (defun bufferlo-set-save-current-interactive ()
-  "Save active constituents in selected bookmark sets."
+  "Save active constituents in selected `bookmark-sets'."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
          (comps (bufferlo--bookmark-completing-read "Select sets to save: "
@@ -2942,7 +2942,7 @@ consider (usually all active bookmarks)."
     (call-interactively 'bufferlo-bookmarks-load-interactive)))
 
 (defun bufferlo--set-clear-all ()
-  "Clear all active bookmark sets.
+  "Clear all active `bookmark-sets'.
 This does not close active frame and tab bookmarks."
   (setq bufferlo--active-sets nil))
 
@@ -2955,7 +2955,7 @@ This does not close associated active frame and tab bookmarks."
         names))
 
 (defun bufferlo-set-clear-interactive ()
-  "Clear the specified bookmark sets.
+  "Clear the specified `bookmark-sets'.
 This does not close its associated bookmarks or kill their buffers."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
@@ -2964,7 +2964,7 @@ This does not close its associated bookmarks or kill their buffers."
     (bufferlo--set-clear comps)))
 
 (defun bufferlo-set-close-interactive ()
-  "Close the specified bookmark sets.
+  "Close the specified `bookmark-sets'.
 This closes their associated bookmarks and kills their buffers."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
@@ -2984,6 +2984,7 @@ This closes their associated bookmarks and kills their buffers."
   "Major mode for bufferlo set list.")
 
 (defun bufferlo--set-list-raise-bookmark-mouse (event)
+  "Handle mouse EVENT."
   (interactive "e")
   (let* ((pos (event-start event))
          (bname (get-text-property (posn-point pos) 'bookmark-name)))
@@ -2991,6 +2992,7 @@ This closes their associated bookmarks and kills their buffers."
     (bufferlo--bookmark-raise-by-name bname)))
 
 (defun bufferlo--set-list-raise-bookmark-kb ()
+  "Handle keyboard event."
   (interactive)
   (let ((bname (get-text-property (point) 'bookmark-name)))
     (quit-window)
@@ -2999,7 +3001,7 @@ This closes their associated bookmarks and kills their buffers."
 (defconst bufferlo--set-list-buffer-name " *bufferlo set list*")
 
 (defun bufferlo-set-list-interactive ()
-  "Enumerate the bookmarks in active bookmark sets."
+  "Enumerate the bookmarks in active `bookmark-sets'."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
          (comps (bufferlo--bookmark-completing-read "Select sets to enumerate: "
@@ -3205,9 +3207,9 @@ This reuses the current tab even if
 
 (defun bufferlo--bookmark-frame-save (name &optional no-overwrite no-message msg)
   "Save the current frame as a bookmark.
-NAME is the bookmark's name. If NO-OVERWRITE is non-nil, record
-the new bookmark without throwing away the old one. If NO-MESSAGE
-is non-nil, inhibit the save status message. If MSG is non-nil,
+NAME is the bookmark's name.  If NO-OVERWRITE is non-nil, record
+the new bookmark without throwing away the old one.  If NO-MESSAGE
+is non-nil, inhibit the save status message.  If MSG is non-nil,
 it is added to the save message."
   (bookmark-store name (bufferlo--bookmark-set-location
                         (bufferlo--bookmark-frame-make))
@@ -3218,18 +3220,18 @@ it is added to the save message."
 
 (defun bufferlo-bookmark-frame-save (name &optional no-overwrite no-message)
   "Save the current frame as a bookmark.
-NAME is the bookmark's name. If NO-OVERWRITE is non-nil, record
-the new bookmark without throwing away the old one. If NO-MESSAGE
+NAME is the bookmark's name.  If NO-OVERWRITE is non-nil, record
+the new bookmark without throwing away the old one.  If NO-MESSAGE
 is non-nil, inhibit the save status message.
 
 This function persists the current frame's state: The resulting bookmark
 stores the frame's window configurations, active tabs, and the local
-buffer lists those tabs. In addition, it saves the bookmark state (not
+buffer lists those tabs.  In addition, it saves the bookmark state (not
 the contents) of the bookmarkable buffers for each tab.
 
 Use `bufferlo-bookmark-tab-in-bookmarked-frame-policy' to
 influence how this function handles setting a frame bookmark in
-the presence of bookmarked tabs. Using both together is allowed,
+the presence of bookmarked tabs.  Using both together is allowed,
 but is not recommended."
   (interactive
    (list (completing-read
@@ -3528,7 +3530,7 @@ TAB is the tab being closed.  _ONLY is for compatibility with the hook."
 (defun bufferlo--bookmarks-save-at-emacs-exit ()
   "Save bufferlo bookmarks at Emacs exit.
 This honors `bufferlo-bookmarks-save-at-emacs-exit' by predicate or
-\\='all. Intended to be invoked via `kill-emacs-hook'."
+\\='all.  Intended to be invoked via `kill-emacs-hook'."
   (bufferlo--bookmarks-auto-save-timer-maybe-cancel)
   (let ((bufferlo-bookmarks-save-predicate-functions
          (if (eq bufferlo-bookmarks-save-at-emacs-exit 'all)

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -3686,13 +3686,13 @@ bookmarks, double for bookmarks, triple for bookmark sets."
           (apply 'bufferlo--bookmark-get-names
                  (cond
                   ((and (consp current-prefix-arg)
-                        (eq (prefix-numeric-value current-prefix-arg) 4))
+                        (= (prefix-numeric-value current-prefix-arg) 4))
                    (list #'bufferlo--bookmark-frame-handler))
                   ((and (consp current-prefix-arg)
-                        (eq (prefix-numeric-value current-prefix-arg) 16))
+                        (= (prefix-numeric-value current-prefix-arg) 16))
                    (list #'bufferlo--bookmark-tab-handler))
                   ((and (consp current-prefix-arg)
-                        (eq (prefix-numeric-value current-prefix-arg) 64))
+                        (= (prefix-numeric-value current-prefix-arg) 64))
                    (list #'bufferlo--bookmark-set-handler))
                   (t bufferlo--bookmark-handlers))))
          (comps (bufferlo--bookmark-completing-read-multiple

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1887,19 +1887,45 @@ The parameters OTHER-WINDOW-P NOSELECT SHRINK are passed to `ibuffer'."
     (ibuffer other-window-p name '((bufferlo-orphan-buffers . nil))
              noselect shrink)))
 
-(define-ibuffer-op ibuffer-do-bufferlo-remove ()
-  "Remove marked buffers from bufferlo's local buffer list."
-  (
-   :active-opstring "remove from bufferlo locals" ; prompt
-   :opstring "removed from bufferlo locals:" ; success
-   :modifier-p t
-   :dangerous t
-   :complex t
-   :after (ibuffer-update nil t)
-   )
-  (when bufferlo-mode
-    (bufferlo-remove buf)
-    t))
+(eval-when-compile
+  (if (< emacs-major-version 31)
+      (define-ibuffer-op ibuffer-do-bufferlo-remove ()
+        "Remove marked buffers from bufferlo's local buffer list."
+        (
+         :active-opstring "remove from bufferlo locals" ; prompt
+         :opstring "removed from bufferlo locals:" ; success
+         :modifier-p t
+         :dangerous t
+         :complex t
+         :after (ibuffer-update nil t)
+         )
+        (when bufferlo-mode
+          (bufferlo-remove buf)
+          t))
+
+    (defun bufferlo--ibuffer-do-bufferlo-remove-prompt (op)
+      "`ibuffer' prompt helper for OP."
+      (let ((bookmark-name (bufferlo--current-bookmark-name)))
+        (format "%s from %slocals:" op
+                (if bookmark-name
+                    (format "bufferlo bookmark \"%s\" " bookmark-name)
+                  ""))))
+
+    (define-ibuffer-op ibuffer-do-bufferlo-remove ()
+      "Remove marked buffers from bufferlo\'s local buffer list."
+      (
+       :active-opstring (lambda ()
+                        (bufferlo--ibuffer-do-bufferlo-remove-prompt "remove"))
+       :opstring (lambda ()
+                 (bufferlo--ibuffer-do-bufferlo-remove-prompt "removed"))
+       :modifier-p t
+       :dangerous t
+       :complex t
+       :after (ibuffer-update nil t)
+       )
+      (when bufferlo-mode
+        (bufferlo-remove buf)
+        t))))
 
 (when bufferlo-ibuffer-bind-keys
   (define-key ibuffer-mode-map "-" #'ibuffer-do-bufferlo-remove))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1343,7 +1343,10 @@ the advised functions.  Honors `bufferlo-bookmark-tab-duplicate-policy'."
     (apply oldfn args))
   (when-let* ((current-tab (bufferlo--current-tab))
               (bookmark-name (alist-get 'bufferlo-bookmark-tab-name current-tab))
-              (abm (assoc bookmark-name (bufferlo--active-bookmarks))))
+              (this+at-least-one-other
+               (when (> (seq-count (lambda (x) (string= bookmark-name (car x)))
+                                   (bufferlo--active-bookmarks)) 1)
+                 t)))
     (let* ((msg nil)
            (msg-append (lambda (s) (setq msg (concat msg "; " s)))))
       (catch :raise
@@ -1362,7 +1365,9 @@ the advised functions.  Honors `bufferlo-bookmark-tab-duplicate-policy'."
                    (funcall msg-append "cleared tab bookmark"))
                   ('raise
                    (tab-bar-close-tab)
-                   (bufferlo--bookmark-raise abm)
+                   ;; Find bookmark to raise; tab numbers changes when closing.
+                   (bufferlo--bookmark-raise
+                    (assoc bookmark-name (bufferlo--active-bookmarks)))
                    (throw :raise t)))
                 (setf (alist-get 'bufferlo-bookmark-tab-name
                                  (cdr current-tab))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -891,10 +891,11 @@ string, FACE is the face for STR."
         (advice-add #'tab-bar-undo-close-tab
                     :around #'bufferlo--tab-bar-undo-close-tab-advice)
         ;; Switch-tab workaround
-        (advice-add #'tab-bar-select-tab
-                    :around #'bufferlo--clear-buffer-lists-activate)
-        (advice-add #'tab-bar--tab
-                    :after #'bufferlo--clear-buffer-lists)
+        (when (< emacs-major-version 31)
+          (advice-add #'tab-bar-select-tab
+                      :around #'bufferlo--clear-buffer-lists-activate)
+          (advice-add #'tab-bar--tab
+                      :after #'bufferlo--clear-buffer-lists))
         ;; Set up bookmarks save timer
         (bufferlo--bookmarks-auto-save-timer-maybe-start)
         ;; kill-emacs-hook save bookmarks option
@@ -941,8 +942,9 @@ string, FACE is the face for STR."
     (advice-remove #'tab-bar-undo-close-tab
                    #'bufferlo--tab-bar-undo-close-tab-advice)
     ;; Switch-tab workaround
-    (advice-remove #'tab-bar-select-tab #'bufferlo--clear-buffer-lists-activate)
-    (advice-remove #'tab-bar--tab #'bufferlo--clear-buffer-lists)
+    (when (< emacs-major-version 31)
+      (advice-remove #'tab-bar-select-tab #'bufferlo--clear-buffer-lists-activate)
+      (advice-remove #'tab-bar--tab #'bufferlo--clear-buffer-lists))
     ;; Cancel bookmarks save timer
     (bufferlo--bookmarks-auto-save-timer-maybe-cancel)
     ;; kill-emacs-hook save bookmarks option

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2513,11 +2513,20 @@ When non-nil, NO-SORT uses the natural order of the CANDIDATES list."
 PROMPT is the prompt text ending with a space.
 CANDIDATES are the prompt options to select.
 When non-nil, NO-SORT uses the natural order of the CANDIDATES list."
-  (let* ((comps
+  (let* ((raw-comps
           (completing-read-multiple
            prompt
            (bufferlo--bookmark-completion-table candidates no-sort)
            nil 'require-match nil 'bufferlo-bookmark-history))
+         (comps (mapcan (lambda (raw-comp)
+                          (let ((tmp-comps
+                                 (completion-all-completions
+                                  raw-comp
+                                  candidates nil nil)))
+                            (when (cdr (last tmp-comps))
+                              (setcdr (last tmp-comps) nil))
+                            tmp-comps))
+                        raw-comps))
          (comps (seq-uniq (mapcar (lambda (x) (substring-no-properties x)) comps))))
     comps))
 


### PR DESCRIPTION
Took a bit of experimentation but this works now.