### PR TITLE
Shipmints handle uniquify

### DIFF
--- a/README.org
+++ b/README.org
@@ -1186,6 +1186,29 @@ remain in force until they are saved if this policy is set to t.
     (bufferlo-anywhere-mode))
 #+end_src
 
+*** CRM prompt enhancement
+
+Bufferlo uses ~completing-read-multiple~ for the prompts where you can
+specify more than one input selection; e.g., when opening multiple
+bookmarks at once using ~bufferlo-bookmarks-load-interactive~. Emacs
+31 will be getting a proper CRM prompt that displays the CRM separator
+character as a reminder hint. Note: The default separator is a comma.
+
+Per https://github.com/minad/vertico#completing-read-multiple from the
+author of the Emacs CRM patch, we recommend adding the following
+snippet to your Emacs configuration.
+
+#+begin_src emacs-lisp
+;; Prompt indicator for `completing-read-multiple'.
+(when (< emacs-major-version 31)
+  (advice-add #'completing-read-multiple :filter-args
+              (lambda (args)
+                (cons (format "[CRM%s] %s"
+                              (string-replace "[ \t]*" "" crm-separator)
+                              (car args))
+                      (cdr args))))))
+#+end_src
+
 * Alternatives
 
 ** desktop.el

--- a/README.org
+++ b/README.org
@@ -45,8 +45,9 @@ with built-in features such as ~bookmark-bmenu-list~ and third-party
 packages such as [[https://github.com/minad/consult][consult]] which offers consult-bookmark for interactive
 bookmark selection.
 
-Bufferlo's mode-line indicator shows the currently active frame and/or
-tab bookmark name and indicates if a set is active.
+Bufferlo's default mode-line indicator shows the currently active
+frame- and/or tab-bookmark name and also indicates if a bookmark set
+is active.
 
 Note: Code examples use ~setq~ to customize options. You may also use
 ~M-x customize-group bufferlo~. Emacs 29 introduced ~setopt~ which
@@ -177,9 +178,11 @@ replacing all tabs, into a new frame, or merged with the current
 frame's tabs. Frames can also store their geometry for later
 restoration.
 
-A set bookmark saves a list of frame and tab bookmark names where
-constituent bookmarks behave as above. Sets can also store frame
-geometry.
+A bookmark set saves a list of frame and tab bookmark names, where
+constituent bookmarks behave as above, and optionally stores each
+frame's geometry. Bufferlo frame and tab bookmarks may be referenced
+by more than one bookmark set which is useful for buffers that are
+common across workflows.
 
 *** General bookmark commands
 
@@ -244,7 +247,8 @@ in combination with a package like [[https://github.com/minad/vertico][vertico]]
 - ~bookmark-bmenu-list~: Typically bound to ~C-x r l~, this loads the
   standard Emacs bookmark menu to select a bookmark and manage the
   bookmark list including non-bufferlo bookmarks. Bufferlo frame
-  bookmarks are identified as "B-Frame" and tab bookmarks as "B-Tab".
+  bookmarks are identified as "B-Frame", tab bookmarks as "B-Tab", and
+  bookmark sets as "B-Set".
 
 - ~bookmark-rename~: Invoke this command to rename a bookmark. This
   command will refuse to rename an active bufferlo bookmark (close or
@@ -256,8 +260,9 @@ in combination with a package like [[https://github.com/minad/vertico][vertico]]
   clear it and then delete). This function is also available via
   ~bookmark-bmenu-list~.
 
-Note: Bookmarks that are embedded in bufferlo bookmark sets will not
-be removed or renamed in the respective bookmark sets.
+Note: Renaming or deleting a bufferlo tab or frame bookmark does not
+rename or delete references to those bookmarks within bufferlo
+bookmark sets.
 
 *** Frame bookmark commands
 
@@ -303,6 +308,11 @@ be removed or renamed in the respective bookmark sets.
   ~bufferlo-bm-tab-load-curr~): Reload the existing bookmark for the
   current tab. This will overwrite your current tab content (no
   buffers are killed).
+
+*** Bookmark set commands
+
++++
+
 
 *** Automatic bookmark saving
 
@@ -533,9 +543,9 @@ bookmarks.
 Restoring bookmarks correctly handles renamed buffers with unchanged
 file association (e.g., when Emacs had to "uniquify" buffer names).
 
-If files are deleted between sessions and a bookmarked buffer cannot
-be restored, after loading a bookmark with a missing file, a message
-similar to this can be found in your ~*Messages*~ buffer:
+If files are deleted between Emacs sessions and a bookmarked buffer
+cannot be restored, after loading a bookmark with a missing file, a
+message similar to this can be found in your ~*Messages*~ buffer:
 
 ~Bufferlo tab: Could not restore emacs-todo.md (error (bookmark-error-no-filename stringp ~/.emacs/emacs-todo.md))~
 
@@ -967,16 +977,21 @@ all-or-nothing solution saving your entire Emacs environment for
 future recall. When you have a long-lived Emacs session that may
 include hundreds of buffers that may not relate to one another or are
 not relevant to your current tasks, ~desktop.el~ is cumbersome and
-slow to restore an entire context. Bufferlo gives you finer-grained
-control over what collections of frames and tabs to save and load.
+slow restoring an entire session when you may need only a subset.
+Bufferlo gives you finer-grained control over what collections of
+frames and tabs to save and load.
 
-Also in contrast to ~desktop.el~, Bufferlo does not store "framesets"
-(though we may concoct a lightweight "session" persistence feature in
-the future), instead relying on your Emacs configuration to create
-frames as you prefer them when restoring bufferlo-managed content.
-This can be more convenient than ~desktop.el~ when you use multiple
-Emacs sessions; e.g., GUI and tty sessions where your frames and tabs
-will have different geometries.
+Similar to ~desktop.el~, bufferlo supports storing "framesets" using
+bufferlo bookmark sets. When a bookmark set is restored, bufferlo
+attempts to recreate your frames with their geometries, and their
+frame and tab bookmarks.
+
+Unlike ~desktop.el~, bufferlo does not persist each buffer's enabled
+major or minor modes, instead relying on your Emacs configuration to
+establish modes, same as when you establish the buffer manually. As
+your configuration evolves, so too will your preferred major and minor
+modes evolve rather than assuming the desktop file will always
+represent your preferences.
 
 ** Other Emacs packages
 

--- a/README.org
+++ b/README.org
@@ -579,11 +579,6 @@ settings.
   (setq bufferlo-bookmark-frame-duplicate-policy 'raise) ; do not load, raise the existing frame
 #+end_src
 Note: 'raise is considered to act as 'clear by bookmark set loading.
-#+begin_src emacs-lisp
-  ;; retain the bookmark when cloning a bookmarked frame via `clone-frame' or C-x 5 c
-  (setq bufferlo-bookmark-frame-clone-policy 'prompt) ; default
-  (setq bufferlo-bookmark-frame-clone-policy 'allow) ; old default behavior
-#+end_src
 
 *** Tab bookmark options
 
@@ -1102,7 +1097,6 @@ remain in force until they are saved if this policy is set to t.
     (setq bufferlo-bookmark-frame-load-make-frame 'restore-geometry)
     (setq bufferlo-bookmark-frame-load-policy 'prompt)
     (setq bufferlo-bookmark-frame-duplicate-policy 'prompt)
-    (setq bufferlo-bookmark-frame-clone-policy 'prompt)
     (setq bufferlo-bookmark-tab-replace-policy 'new)
     (setq bufferlo-bookmark-tab-duplicate-policy 'prompt)
     (setq bufferlo-bookmark-tab-in-bookmarked-frame-policy 'prompt)

--- a/README.org
+++ b/README.org
@@ -637,6 +637,23 @@ bookmark set is loaded.
   (setq bufferlo-set-restore-tabs-reuse-init-frame nil) ; always make new frames
 #+end_src
 
+*** Bookmark handler hooks
+
+You can add your own functions to the following abnormal hooks to be
+called upon successful loading of tab, frame, and set bookmarks. See
+the docstrings for each function for its calling conventions.
+
+Example: You could use a tab handler function to set the tab-bar group
+for each loaded tab to its source bookmark name. While tab-bar does
+have ~tab-bar-tab-post-open-functions~, the bookmark context will not
+be available when those functions are called.
+
+#+begin_src emacs-lisp
+  (add-hook 'bufferlo-bookmark-tab-handler-functions #'tab-bookmark-fun)
+  (add-hook 'bufferlo-bookmark-frame-handler-functions #'frame-bookmark-fun)
+  (add-hook 'bufferlo-bookmark-set-handler-functions #'set-bookmark-fun)
+#+end_src
+
 *** Frame geometry options
 
 Bufferlo provides wrappers around Emacs frame functions to provide

--- a/README.org
+++ b/README.org
@@ -652,6 +652,9 @@ Frame bookmarks saved via Emacs tty will not store a frame geometry
 (none available on tty). Conversely, frame bookmarks saved via GUI and
 restored on tty will ignore frame geometry.
 
+Note: See below to adjust ~bufferlo-frame-sleep-for~ for your window
+manager.
+
 Note: Not much testing has been done in hybrid tty/GUI environments
 using ~emacsclient~, or with multi-display setups where frames may be
 expected to be restored on their originating displays.
@@ -662,6 +665,19 @@ expected to be restored on their originating displays.
   (setq bufferlo-frame-geometry-function #'bufferlo-frame-geometry-default) ; the default uses text-width and text-height
   (setq bufferlo-frame-geometry-function #'my/bufferlo-frame-geometry) ; or your own
 #+end_src
+#+begin_src emacs-lisp
+  ;; function to set a frame's pixelwise geometry (it is not likely you
+  ;; will need to replace this--but is provided just in case)
+  (setq bufferlo-set-frame-geometry-function #'bufferlo-set-frame-geometry-default)
+  (setq bufferlo-set-frame-geometry-function #'my/bufferlo-set-frame-geometry) ; or your own
+#+end_src
+#+begin_src emacs-lisp
+  ;; seconds to sleep after each frame parameter change that requires
+  ;; external window manager cooperation.
+  (setq bufferlo-frame-sleep-for 0) ; the default, which seems to work on macOS
+  (setq bufferlo-frame-sleep-for 0.3) ; seems to work for GTK/GNOME
+#+end_src
+
 #+begin_src emacs-lisp
   ;; methodology for bookmark-set frameset geometry restoration
   (setq bufferlo-frameset-restore-geometry 'bufferlo) ; the pixel-level precision default

--- a/README.org
+++ b/README.org
@@ -56,7 +56,7 @@ Note: Code examples use ~setq~ to customize options. You may also use
 ~M-x customize-group bufferlo~. Emacs 29 introduced ~setopt~ which
 works correctly in the presence of ~defcustom~ setters. Currently the
 only bufferlo option with such a setter is
-~bufferlo-bookmarks-auto-save-idle-interval~ so be sure to set that
+~bufferlo-bookmarks-auto-save-interval~ so be sure to set that
 interval timer in advance of enabling ~bufferlo-mode~.
 
 Note: Many bufferlo commands have short-hand aliases to accommodate
@@ -407,8 +407,8 @@ To set the automatic save timer, set the number of whole integer
 seconds between saves that you prefer, or 0, the default, to disable
 the timer:
 #+begin_src emacs-lisp
-  (setq bufferlo-bookmarks-auto-save-idle-interval 120) ; do this in advance of enabling `bufferlo-mode'
-  (setopt bufferlo-bookmarks-auto-save-idle-interval 120) ; or use setopt, to invoke the custom setter
+  (setq bufferlo-bookmarks-auto-save-interval 120) ; do this in advance of enabling `bufferlo-mode'
+  (setopt bufferlo-bookmarks-auto-save-interval 120) ; or use setopt, to invoke the custom setter
 #+end_src
 
 By default, bufferlo will save all active bookmarks. To select the
@@ -1106,7 +1106,7 @@ remain in force until they are saved if this policy is set to t.
     (setq bufferlo-bookmarks-save-at-emacs-exit-policy 'all)
     (setq bufferlo-bookmarks-load-at-emacs-startup 'pred)
     (setq bufferlo-bookmarks-load-at-emacs-startup-tabs-make-frame nil)
-    (setopt bufferlo-bookmarks-auto-save-idle-interval (* 60 5)) ; 5 minutes
+    (setopt bufferlo-bookmarks-auto-save-interval (* 60 5)) ; 5 minutes
     (setq bufferlo-bookmarks-auto-save-messages 'saved)
     (setq bufferlo-set-restore-geometry-policy 'all)
     (setq bufferlo-set-restore-tabs-reuse-init-frame 'reuse) ; nil 'reuse 'reuse-reset-geometry

--- a/README.org
+++ b/README.org
@@ -337,6 +337,13 @@ rename or delete references to those bookmarks within bookmark sets.
   the specified bookmark sets. This closes their constituent bookmarks
   and kills their buffers.
 
+- ~bufferlo-set-list-interactive~ (alias ~bufferlo-set-list~): List
+  the constituent bookmarks of the selected active sets in a
+  ~special-mode~ buffer and pop to it. The display shows each
+  bookmark's name, its type, the frame it's currently on, and, if a
+  tab bookmark, its tab number. Typing ~<RET>~ or clicking ~mouse-1~
+  will raise the selected bookmark. Type "q" to quit.
+
 Notes:
 
 - To curate a saved bookmark set, invoke
@@ -1015,11 +1022,11 @@ remain in force until they are saved if this policy is set to t.
      ("C-z C-b" . bufferlo-ibuffer)
      ("C-z M-C-b" . bufferlo-ibuffer-orphans)
      ("C-z b -" . bufferlo-remove)
-     ;; interactive
-     ("C-z i l" . bufferlo-bms-load)
-     ("C-z i s" . bufferlo-bms-save)
-     ("C-z i c" . bufferlo-bms-close)
-     ("C-z i r" . bufferlo-bm-raise)
+     ;; general bookmark (interactive)
+     ("C-z b l" . bufferlo-bms-load)
+     ("C-z b s" . bufferlo-bms-save)
+     ("C-z b c" . bufferlo-bms-close)
+     ("C-z b r" . bufferlo-bm-raise)
      ;; dwim frame or tab bookmarks
      ("C-z d s" . bufferlo-bm-save)
      ("C-z d l" . bufferlo-bm-load)
@@ -1043,6 +1050,7 @@ remain in force until they are saved if this policy is set to t.
      ("C-z s l" . bufferlo-set-load)                  ; load
      ("C-z s 0" . bufferlo-set-close)                 ; kill
      ("C-z s c" . bufferlo-set-clear)                 ; clear
+     ("C-z s L" . bufferlo-set-list)                  ; list contents of selected active sets
      )
     :init
     ;; these must be set before the bufferlo package is loaded
@@ -1081,6 +1089,7 @@ remain in force until they are saved if this policy is set to t.
                   "\\)\\*\\)"
                   "\\|" (rx "*" (1+ anything) " Ibuffer*")
                   "\\|" (rx "*helpful " (1+ anything) "*")
+                  "\\|" (rx "*tramp" (1+ anything) "*")
                   "\\|" (rx "magit" (* anything) ": " (1+ anything))
                   "\\'"))
     (setq bufferlo-kill-buffers-prompt t)

--- a/README.org
+++ b/README.org
@@ -46,8 +46,11 @@ packages such as [[https://github.com/minad/consult][consult]] which offers cons
 bookmark selection.
 
 Bufferlo's default mode-line indicator shows the currently active
-frame- and/or tab-bookmark name and also indicates if a bookmark set
-is active.
+frame- and/or tab-bookmark name and also indicates if at least one
+bookmark set is active.
+
+A bufferlo menu bar is enabled by default to encourage discovery of
+bufferlo features.
 
 Note: Code examples use ~setq~ to customize options. You may also use
 ~M-x customize-group bufferlo~. Emacs 29 introduced ~setopt~ which
@@ -179,9 +182,9 @@ frame's tabs. Frames can also store their geometry for later
 restoration.
 
 A bookmark set saves a list of frame and tab bookmark names, where
-constituent bookmarks behave as above, and optionally stores each
+constituent bookmarks behave as above, and can optionally restore each
 frame's geometry. Bufferlo frame and tab bookmarks may be referenced
-by more than one bookmark set which is useful for buffers that are
+in multiple bookmark sets which can be useful for buffers that are
 common across workflows.
 
 *** General bookmark commands
@@ -261,8 +264,7 @@ in combination with a package like [[https://github.com/minad/vertico][vertico]]
   ~bookmark-bmenu-list~.
 
 Note: Renaming or deleting a bufferlo tab or frame bookmark does not
-rename or delete references to those bookmarks within bufferlo
-bookmark sets.
+rename or delete references to those bookmarks within bookmark sets.
 
 *** Frame bookmark commands
 
@@ -311,8 +313,81 @@ bookmark sets.
 
 *** Bookmark set commands
 
-+++
+- ~bufferlo-set-save-interactive~ (alias ~bufferlo-set-save~): Save a
+  bufferlo bookmark set for the specified active bookmarks. Frame
+  bookmark names are stored along with their geometry for optional
+  restoration. Tab bookmark names are grouped based on their shared
+  frames along with each frame's geometry.
 
+- ~bufferlo-set-save-current-interactive~ (alias
+  ~bufferlo-set-save-curr~): Update the content of all active
+  constituent bookmarks in selected bookmark sets.
+
+- ~bufferlo-set-load-interactive~ (alias ~bufferlo-set-load~): Prompt
+  to load bufferlo set bookmarks. This will restore each set's
+  constituent frame and tab bookmarks along with the tab bookmarks'
+  shared frames. Frame geometry is optionally restored.
+
+- ~bufferlo-set-clear-interactive~ (alias ~bufferlo-set-clear~): Clear
+  the specified bookmark sets. This has the effect of leaving the
+  set's constituent frame and tab bookmarks in place while indicating that
+  the bookmark sets are no longer active.
+
+- ~bufferlo-set-close-interactive~ (alias ~bufferlo-set-close~): Close
+  the specified bookmark sets. This closes their constituent bookmarks
+  and kills their buffers.
+
+Notes:
+
+- To curate a saved bookmark set, invoke
+  ~bufferlo-set-save-interactive~ and save a new set of active
+  bookmarks, replacing the existing bookmark set.
+- Bookmark sets are unaware of constituent frame and tab bookmark
+  renames or deletes.
+- Bookmark sets are Emacs bookmarks and can be deleted or renamed
+  using Emacs bookmark commands; e.g., via ~bookmark-bmenu-list~.
+- While bookmark sets can be auto loaded, just as individual frame and
+  tab bookmarks can be, bookmark sets cannot themselves be auto-saved.
+  Constituent bookmarks are saved individually based on your auto-save
+  predicates.
+
+*** DWIM commands
+
+These do-what-I-mean aka DWIM commands are conveniences that detect an
+active frame or tab bookmark avoiding the need to to specify the frame
+or tab variants of the equivalent commands.
+
+Note: Bufferlo DWIM commands prioritize frame bookmarks over tab
+bookmarks should both exist.
+
+- ~bufferlo-bookmark-save-curr~ (alias ~bufferlo-bm-save~): Save the
+  current frame or tab bookmark. This does not prompt to save a new
+  bookmark if no bookmark is established.
+
+- ~bufferlo-bookmark-load-curr~ (alias ~bufferlo-bm-load~): Reload the
+  current frame or tab bookmark. This does not prompt to load a new
+  bookmark if no bookmark is established.
+
+- ~bufferlo-bookmark-close-curr~ (alias ~bufferlo-bm-close~): Close
+  current frame or tab bookmark and kill its buffers.
+
+*** Bufferlo buffer killing policies
+
+To control bufferlo confirmation prompts when killing local or orphan
+buffers:
+#+begin_src emacs-lisp
+  (setq bufferlo-kill-buffers-prompt t) ; default nil
+#+end_src
+
+To control bufferlo behavior when closing frame or tab bookmarks and
+killing their local modified buffers or process buffers such as
+~shell-mode~ or ~eshell-mode~:
+#+begin_src emacs-lisp
+  (setq bufferlo-kill-modified-buffers-policy nil) ; use normal Emacs prompting behavior
+  (setq bufferlo-kill-modified-buffers-policy 'retain-modified) ; kill just unmodified
+  (setq bufferlo-kill-modified-buffers-policy 'retain-modified-kill-without-file-name) ; kill unmodified and buffers without files
+  (setq bufferlo-kill-modified-buffers-policy 'kill-modified) ; kill local buffers without prompting; the default
+#+end_src
 
 *** Automatic bookmark saving
 
@@ -381,7 +456,8 @@ your context as you work. Switch between them as you see fit.
 *** Automatic bookmark loading
 
 To automatically load some or all bufferlo bookmarks at Emacs startup
-time:
+time (bufferlo uses ~window-setup-hook~ to load bookmarks after your
+init.el has completed to maximize the chances for successful loading):
 #+begin_src emacs-lisp
   (setq bufferlo-bookmarks-load-at-emacs-startup 'noload) ; inhibit loading at startup (default)
   (setq bufferlo-bookmarks-load-at-emacs-startup 'pred) ; load bookmark names that match your predicates
@@ -404,9 +480,10 @@ Example auto-load predicate:
   (add-hook 'bufferlo-bookmarks-load-predicate-functions #'my/bufferlo-bookmarks-load-p)
 #+end_src
 
-You can inhibit bufferlo bookmarks from loading at Emacs startup
-without changing your configuration by either using the command line
-or a semaphore file in your ~user-emacs-directory~:
+If you have configured bufferlo to load bookmarks at Emacs startup,
+you can inhibit bookmark loading without changing your configuration
+by either using the command line or a semaphore file in your
+~user-emacs-directory~:
 #+begin_src shell
 $ emacs --bufferlo-noload
 $ touch ~/.emacs.d/bufferlo-noload # remove it to reenable automatic loading
@@ -422,7 +499,6 @@ support such as ~*shell*~ buffers. To do that, combine the following
 two variables, the first to exclude what you want to filter, and the
 second to ensure that the buffers you want to keep from the first
 filter are added back. For example:
-
 #+begin_src emacs-lisp
   (setq bufferlo-bookmark-buffers-exclude-filters
         (list
@@ -471,13 +547,14 @@ have their current working set be saved unless and until they choose.
 
 *** Frame bookmark options
 
-What follows is a good, basic set of frame bookmark policies. Refine
-them to suit your workflow as you gain experience with bufferlo. Refer
-to each option's documentation for additional settings.
+Refine these options to suit your workflow as you gain experience with
+bufferlo. Refer to each option's documentation for additional
+settings.
 
 #+begin_src emacs-lisp
   ;; make a new frame to hold loaded frame bookmarks
   (setq bufferlo-bookmark-frame-load-make-frame t) ; default is nil for backward compatibility
+  (setq bufferlo-bookmark-frame-load-make-frame 'restore-geometry)
 #+end_src
 #+begin_src emacs-lisp
   ;; policy when loading onto an already bookmarked frame
@@ -500,9 +577,9 @@ to each option's documentation for additional settings.
 
 *** Tab bookmark options
 
-What follows is a good, basic set of tab bookmark policies. Refine
-them to suit your workflow as you gain experience with bufferlo. Refer
-to each option's documentation for additional settings.
+Refine these options to suit your workflow as you gain experience with
+bufferlo. Refer to each option's documentation for additional
+settings.
 
 #+begin_src emacs-lisp
    ;; make a new frame when loading a a batch of tab bookmarks
@@ -523,11 +600,105 @@ to each option's documentation for additional settings.
   (setq bufferlo-bookmark-tab-duplicate-policy 'raise) ; do not load, raise the existing frame/tab
 #+end_src
 #+begin_src emacs-lisp
-  ;; allow inferior tab bookmark on a bookmarked frame which will supersede the tab when saving
-  (setq bufferlo-bookmark-tab-load-into-bookmarked-frame-policy 'prompt) ; default
-  (setq bufferlo-bookmark-tab-load-into-bookmarked-frame-policy 'allow) ; old default behavior
-  (setq bufferlo-bookmark-tab-load-into-bookmarked-frame-policy 'clear) ; silently clear the loaded tab bookmark
-  (setq bufferlo-bookmark-tab-load-into-bookmarked-frame-policy 'clear-warn) ; clear the loaded tab bookmark with a message
+  ;; allow inferior tab bookmark on a bookmarked frame (Note: frame bookmarks supersede tab bookmarks when saving)
+  (setq bufferlo-bookmark-tab-in-bookmarked-frame-policy 'prompt) ; default
+  (setq bufferlo-bookmark-tab-in-bookmarked-frame-policy 'allow) ; old default behavior
+  (setq bufferlo-bookmark-tab-in-bookmarked-frame-policy 'clear) ; silently clear the loaded tab bookmark
+  (setq bufferlo-bookmark-tab-in-bookmarked-frame-policy 'clear-warn) ; clear the loaded tab bookmark with a message
+#+end_src
+
+*** Bookmark set options
+
+Refine these options to suit your workflow as you gain experience with
+bufferlo. Refer to each option's documentation for additional
+settings.
+
+#+begin_src emacs-lisp
+  ;; frame geometry restoration policy
+  (setq bufferlo-set-restore-geometry-policy 'all) ; restore frame and tab-frame geometries; the default
+  (setq bufferlo-set-restore-geometry-policy 'frames) ; restore only frame geometries
+  (setq bufferlo-set-restore-geometry-policy 'tab-frames) ; restore only tab-frame geometries
+#+end_src
+
+The following option is useful for auto-loading bookmark sets at
+startup time or overlaying constituent tabs in the frame from which a
+bookmark set is loaded.
+
+#+begin_src emacs-lisp
+  ;; make a new frame when loading a a batch of tab bookmarks
+  (setq bufferlo-set-restore-tabs-reuse-init-frame 'reuse) ; reuse the existing first frame; the default
+  (setq bufferlo-set-restore-tabs-reuse-init-frame 'reuse-reset-geometry) ; like 'reuse but also alters the reused frame's geometry
+  (setq bufferlo-set-restore-tabs-reuse-init-frame nil) ; always make new frames
+#+end_src
+
+*** Frame geometry options
+
+Bufferlo provides wrappers around Emacs frame functions to provide
+more precision. This is due to issues that affect ~make-frame~ and
+hence ~frameset-restore~. One bug preventing pixel-level precision was
+reported and fixed for Emacs 31 (it was too late for the Emacs 30
+release cycle).
+
+Frames stored in bufferlo frame bookmarks have their geometries stored
+individually and are recreated on demand. Bookmark sets frame
+collections are implemented via ~frameset-save~ and are restored by
+Emacs en masse.
+
+Frame bookmarks saved via Emacs tty will not store a frame geometry
+(none available on tty). Conversely, frame bookmarks saved via GUI and
+restored on tty will ignore frame geometry.
+
+Note: Not much testing has been done in hybrid tty/GUI environments
+using ~emacsclient~, or with multi-display setups where frames may be
+expected to be restored on their originating displays.
+
+#+begin_src emacs-lisp
+  ;; function to determine a frame's pixelwise geometry (it is not
+  ;; likely you will need to replace this--but is provided just in case)
+  (setq bufferlo-frame-geometry-function #'bufferlo-frame-geometry-default) ; the default uses text-width and text-height
+  (setq bufferlo-frame-geometry-function #'my/bufferlo-frame-geometry) ; or your own
+#+end_src
+#+begin_src emacs-lisp
+  ;; methodology for bookmark-set frameset geometry restoration
+  (setq bufferlo-frameset-restore-geometry 'bufferlo) ; the pixel-level precision default
+  (setq bufferlo-frameset-restore-geometry 'native) ; uses `frameset-restore' geometry handling (buggy pre Emacs 31)
+  (setq bufferlo-frameset-restore-geometry nil) ; inhibit frame geometry restoration
+#+end_src
+#+begin_src emacs-lisp
+  ;; inhibit additional frame parameter symbols from being stored by `frameset-save'
+  (setq bufferlo-frameset-save-filter nil)
+  (setq bufferlo-frameset-save-filter '(my:frame-id ; practical example
+                                        zoom--frame-snapshot))
+#+end_src
+#+begin_src emacs-lisp
+    ;; inhibit additional frame parameter symbols from being restored by `frameset-restore'
+    (setq bufferlo-frameset-restore-filter nil)
+#+end_src
+#+begin_src emacs-lisp
+  ;; you can override bufferlos `frameset-restore' wrapper should you need to
+  (setq bufferlo-frameset-restore-function #'bufferlo-frameset-restore-default) ; the default
+  ;; a practical example that inhibits user-configured
+  ;; `after-make-frame-functions' frame maximization by let-binding
+  ;; my:frame-maximize to nil allowing `frameset-restore' and bufferlo
+  ;; to control restored frame geometry.
+  (defun my/bufferlo-frameset-restore-function (frameset)
+    (let ((my:frame-maximize nil))
+      (bufferlo-frameset-restore-default frameset)))
+  (setq bufferlo-frameset-restore-function #'my/bufferlo-frameset-restore-function)
+#+end_src
+#+begin_src emacs-lisp
+  (setq bufferlo-frameset-restore-parameters-function #'bufferlo-frameset-restore-parameters-default) ; default
+  ;; a practical example where Emacs Linux/GTK behaves differently vs. macOS
+  (defun my/bufferlo-frameset-restore-parameters ()
+    "Function to create parameters for `frameset-restore', which see."
+    (cond (my:on-linux-gnome
+           (list :reuse-frames nil
+                 :force-display nil ; bufferlo defaults to t which works on macOS
+                 :force-onscreen (display-graphic-p)
+                 :cleanup-frames nil))
+          (t
+           (bufferlo-frameset-restore-parameters-default))))
+  (setq bufferlo-frameset-restore-parameters-function #'my/bufferlo-frameset-restore-parameters)
 #+end_src
 
 *** Bookmark addenda
@@ -567,15 +738,63 @@ following assumptions:
 
 *** mode-line
 
-- If you prefer iconic lighter prefixes, set one like this:
+- If you prefer iconic mode-line prefixes, set one like this:
 #+begin_src emacs-lisp
-  (setq bufferlo-mode-line-lighter-prefix " 🐮") ; bufferlos are cows
-  (setq bufferlo-mode-line-lighter-prefix " 🐃") ; some are water bufferlos
+   (setq bufferlo-mode-line-prefix "🐮") ; bufferlos are cows
+   (setq bufferlo-mode-line-prefix "🐃") ; some are water bufferlos
+   (setq bufferlo-mode-line-prefix "Bfl") ; the text default
 #+end_src
 - To disable bufferlo's mode-line or provide your own custom mode-line function:
 #+begin_src emacs-lisp
-  (setq bufferlo-mode-line-lighter nil) ; disable the bufferlo mode-line
-  (setq bufferlo-mode-line-lighter #'my/bufferlo-mode-line-lighter) ; use your own
+  (setq bufferlo-mode-line nil) ; disable the bufferlo mode-line
+  (setq bufferlo-mode-line #'my/bufferlo-mode-line) ; or use your own
+#+end_src
+- To control the appearance of other mode-line features:
+#+begin_src emacs-lisp
+  (setq bufferlo-mode-line-set-active-prefix "Ⓢ")
+  (setq bufferlo-mode-line-frame-prefix "Ⓕ")
+  (setq bufferlo-mode-line-tab-prefix "Ⓣ")
+  (setq bufferlo-mode-line-left-prefix nil) ; default "[" similar to flymake
+  (setq bufferlo-mode-line-right-suffix nil) ; default "]"
+#+end_src
+- To control mode-line faces:
+#+begin_src emacs-lisp
+  (set-face-attribute 'bufferlo-mode-line-face nil
+                      :box '(:line-width (-1 . -1) :color "#8aca9f")
+                      :height 0.85)
+  ;; below inherit bufferlo-mode-line-face
+  (set-face-attribute 'bufferlo-mode-line-frame-bookmark-face nil
+                      :foreground "#8aca0f")
+  (set-face-attribute 'bufferlo-mode-line-tab-bookmark-face nil
+                      :foreground "#00ffff")
+  (set-face-attribute 'bufferlo-mode-line-set-face nil
+                      :foreground "#000fff")
+#+end_src
+
+*** Menu bar
+
+Bufferlo enables its menu bar entry by default to encourage feature
+discovery and menu-item entries are adorned with key mappings from
+your configuration.
+
+Note: Due to a limitation in Emacs where it does not reference key
+bindings of commands via aliases, you must provide key mappings on
+bufferlo's aliased commands, as the menu is defined in alias terms. We
+default to aliases to reduce the text displayed by ~which-key-mode~ to
+a readable width vs. fully-qualified command names.
+
+#+begin_src emacs-lisp
+  ;; To control the menu bar visibility before package initialization
+  (setq bufferlo-menu-bar-show t) ; the default
+  (setq bufferlo-menu-bar-show nil)
+#+end_src
+
+#+begin_src emacs-lisp
+  ;; bufferlo menu buffer window behavior
+  (setq bufferlo-menu-bar-list-buffers 'simple) ; show buffer lists using `Buffer-menu-mode'
+  (setq bufferlo-menu-bar-list-buffers 'ibuffer) ; show buffer lists using `ibuffer'
+  (setq bufferlo-menu-bar-list-buffers 'both) ; show both options; the default
+  (setq bufferlo-menu-bar-list-buffers nil) ; show neither
 #+end_src
 
 ** Initial buffer
@@ -758,9 +977,9 @@ positions, add this to your configuration:
   (setq bufferlo-bookmark-inhibit-bookmark-point t)
 #+end_src
 
-This takes effect when saving or updating a Bufferlo bookmark.
-Existing bookmarks with embedded point will remain in force until
-saved.
+This takes effect when saving or updating a bufferlo bookmark.
+Previously stored bufferlo bookmarks with an embedded point will
+remain in force until they are saved if this policy is set to t.
 
 ** Complete configuration sample
 
@@ -858,7 +1077,6 @@ saved.
     (setq bufferlo-bookmark-tab-replace-policy 'new)
     (setq bufferlo-bookmark-tab-duplicate-policy 'prompt)
     (setq bufferlo-bookmark-tab-in-bookmarked-frame-policy 'prompt)
-    ;; +++ (setq bufferlo-bookmark-tab-load-into-bookmarked-frame-policy 'prompt)
     (setq bufferlo-bookmarks-save-duplicates-policy 'prompt)
     (setq bufferlo-bookmarks-save-frame-policy 'all)
     (setq bufferlo-bookmarks-load-tabs-make-frame t)
@@ -871,28 +1089,6 @@ saved.
     (setq bufferlo-set-restore-tabs-reuse-init-frame 'reuse) ; nil 'reuse 'reuse-reset-geometry
     (setq bufferlo-frameset-restore-geometry 'bufferlo)
     (setq bufferlo-frame-geometry-function #'bufferlo-frame-geometry-default)
-
-    (defun my/bufferlo-frameset-restore-parameters ()
-      "Function to create parameters for `frameset-restore', which see."
-      (cond (my:on-linux-gnome
-             (list :reuse-frames nil
-                   :force-display nil ; default t
-                   :force-onscreen (display-graphic-p)
-                   :cleanup-frames nil))
-            (t
-             (bufferlo-frameset-restore-parameters-default))))
-    (setq bufferlo-frameset-restore-parameters-function #'my/bufferlo-frameset-restore-parameters)
-
-    (setq bufferlo-frameset-save-filter
-          '(my:frame-id
-            zoom--frame-snapshot))
-
-    (setq bufferlo-frameset-restore-filter nil)
-
-    (defun my/bufferlo-frameset-restore-function (frameset)
-      (let ((my:frame-maximize nil))
-        (bufferlo-frameset-restore-default frameset)))
-    (setq bufferlo-frameset-restore-function #'my/bufferlo-frameset-restore-function)
 
     (setq bufferlo-bookmark-buffers-exclude-filters
           (list
@@ -963,8 +1159,7 @@ saved.
     (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-local-buffers)
 
     (bufferlo-mode)
-    (bufferlo-anywhere-mode)
-    )
+    (bufferlo-anywhere-mode))
 #+end_src
 
 * Alternatives
@@ -991,7 +1186,11 @@ major or minor modes, instead relying on your Emacs configuration to
 establish modes, same as when you establish the buffer manually. As
 your configuration evolves, so too will your preferred major and minor
 modes evolve rather than assuming the desktop file will always
-represent your preferences.
+represent your preferences. One typical example of an optional minor
+mode is ~treesit-explore-mode~ which you might use to understand
+treesitter behaviors. This minor mode will not be reenabled by
+bufferlo. If you want this behavior automatically, add
+~treesit-explore-mode~ to your major-mode hook.
 
 ** Other Emacs packages
 

--- a/README.org
+++ b/README.org
@@ -747,8 +747,8 @@ references to your files and buffers. Many Emacs modes support Emacs
 bookmarks and can be saved and recalled including ~eshell~ and
 ~magit-status~ buffers. The state of non-bookmarkable buffers is not
 saved. However, during bookmark saving, they are included in the
-bookmark record. At this time, Emacs does not support ~*shell*~ buffer
-bookmarks.
+bookmark record. Emacs 31 has support for ~shell-mode~ local and
+remote buffer bookmarks.
 
 Restoring bookmarks correctly handles renamed buffers with unchanged
 file association (e.g., when Emacs had to "uniquify" buffer names).
@@ -1130,6 +1130,8 @@ remain in force until they are saved if this policy is set to t.
     (setq bufferlo-frameset-restore-geometry 'bufferlo)
     (setq bufferlo-frame-geometry-function #'bufferlo-frame-geometry-default)
     (setq bufferlo-frame-sleep-for 0.3)
+
+    (setq bookmark-bmenu-type-column-width 12) ; supported in Emacs 31 (innocuous on earlier versions)
 
     (setq bufferlo-bookmark-buffers-exclude-filters
           (list

--- a/README.org
+++ b/README.org
@@ -1112,6 +1112,7 @@ remain in force until they are saved if this policy is set to t.
     (setq bufferlo-set-restore-tabs-reuse-init-frame 'reuse) ; nil 'reuse 'reuse-reset-geometry
     (setq bufferlo-frameset-restore-geometry 'bufferlo)
     (setq bufferlo-frame-geometry-function #'bufferlo-frame-geometry-default)
+    (setq bufferlo-frame-sleep-for 0.3)
 
     (setq bufferlo-bookmark-buffers-exclude-filters
           (list

--- a/README.org
+++ b/README.org
@@ -660,8 +660,9 @@ This is an example configuration:
                                 :as #'buffer-name)))
     "Non-local Bufferlo buffer candidate source for `consult-buffer'.")
 
-  (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-local-buffers)
+  ;; add in the reverse order of display preference
   (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-other-buffers)
+  (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-local-buffers)
 #+end_src
 
 [[./img/consult1.svg]]
@@ -696,6 +697,7 @@ You can also configure ~consult-buffer~ to hide the non-local buffers by default
                                 :as #'buffer-name)))
     "Local Bufferlo buffer candidate source for `consult-buffer'.")
 
+  ;; add in the reverse order of display preference
   (add-to-list 'consult-buffer-sources #'consult--source-hidden-buffer)
   (add-to-list 'consult-buffer-sources #'my:bufferlo-consult--source-all-buffers)
   (add-to-list 'consult-buffer-sources #'my:bufferlo-consult--source-local-buffers)
@@ -945,9 +947,10 @@ saved.
                                   :as #'buffer-name)))
       "All Bufferlo buffer candidate source for `consult-buffer'.")
 
-    (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-local-buffers)
-    (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-other-buffers)
+    ;; add in the reverse order of display preference
     (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-all-buffers)
+    (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-other-buffers)
+    (add-to-list 'consult-buffer-sources 'my:bufferlo-consult--source-local-buffers)
 
     (bufferlo-mode)
     (bufferlo-anywhere-mode)

--- a/README.org
+++ b/README.org
@@ -567,8 +567,11 @@ settings.
   ;; allow duplicate active frame bookmarks in the Emacs session
   (setq bufferlo-bookmark-frame-duplicate-policy 'prompt) ; default
   (setq bufferlo-bookmark-frame-duplicate-policy 'allow) ; old default behavior
+  (setq bufferlo-bookmark-frame-duplicate-policy 'clear) ; silently clear the loaded frame bookmark
+  (setq bufferlo-bookmark-frame-duplicate-policy 'clear-warn) ; clear the loaded frame bookmark with a message
   (setq bufferlo-bookmark-frame-duplicate-policy 'raise) ; do not load, raise the existing frame
 #+end_src
+Note: 'raise is considered to act as 'clear by bookmark set loading.
 #+begin_src emacs-lisp
   ;; retain the bookmark when cloning a bookmarked frame via `clone-frame' or C-x 5 c
   (setq bufferlo-bookmark-frame-clone-policy 'prompt) ; default
@@ -599,6 +602,7 @@ settings.
   (setq bufferlo-bookmark-tab-duplicate-policy 'clear-warn) ; clear the loaded tab bookmark with a message
   (setq bufferlo-bookmark-tab-duplicate-policy 'raise) ; do not load, raise the existing frame/tab
 #+end_src
+Note: 'raise is considered to act as 'clear by bookmark set loading.
 #+begin_src emacs-lisp
   ;; allow inferior tab bookmark on a bookmarked frame (Note: frame bookmarks supersede tab bookmarks when saving)
   (setq bufferlo-bookmark-tab-in-bookmarked-frame-policy 'prompt) ; default

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2755,7 +2755,7 @@ the message after successfully restoring the bookmark."
                (bufferlo--bookmark-jump tbm-name)
                (setq first-tab nil))))
          (setq first-tab-frame nil)))
-      (raise-frame))
+      (select-frame-set-input-focus (selected-frame)))
 
     ;; Restore framesets (framesets can be nil despite readablep)
     (when-let ((frameset (car (read-from-string frameset-str))))
@@ -2780,7 +2780,7 @@ the message after successfully restoring the bookmark."
                 (when-let* ((fg (frame-parameter nil 'bufferlo--frame-geometry)))
                   (funcall bufferlo-set-frame-geometry-function fg)))
               (set-frame-parameter nil 'bufferlo--frame-to-restore nil))
-            (raise-frame)))))
+            (select-frame-set-input-focus (selected-frame))))))
 
     ;; Add the set to the active list
     (push `(,bookmark-name (bufferlo-bookmark-names . ,bufferlo-bookmark-names))
@@ -3746,14 +3746,14 @@ which defaults to all frames, if not specified."
         (with-selected-frame abm-frame
           ;; If called in a batch, raise frame in case of prompts for buffers
           ;; that need saving:
-          (raise-frame)
+          (select-frame-set-input-focus (selected-frame))
           (tab-bar-select-tab abm-tab-number)
           (let ((bufferlo-kill-buffers-prompt nil)
                 (bufferlo-bookmark-tab-save-on-close nil)
                 (bufferlo-close-tab-kill-buffers-prompt nil))
             (bufferlo-tab-close-kill-buffers)))
         (when (frame-live-p orig-frame)
-          (raise-frame orig-frame))))
+          (select-frame-set-input-focus orig-frame))))
     (dolist (abm fbms)
       (let ((abm-frame (alist-get 'frame (cadr abm))))
         (with-selected-frame abm-frame
@@ -3807,7 +3807,7 @@ A prefix argument inhibits the prompt and bypasses saving."
   (when-let* ((abm-type (alist-get 'type (cadr abm)))
               (abm-frame (alist-get 'frame (cadr abm))))
     (with-selected-frame abm-frame
-      (raise-frame)
+      (select-frame-set-input-focus (selected-frame))
       (when (eq abm-type 'tbm)
         (tab-bar-select-tab
          (alist-get 'tab-number (cadr abm)))))))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2856,7 +2856,7 @@ message."
     (setq tabsets
           (mapcar (lambda (group)
                     (let ((tbm-frame (car group))
-                          (tbm-names (mapcar #'car (cdr group))))
+                          (tbm-names (nreverse (mapcar #'car (cdr group)))))
                       `((bufferlo--frame-geometry
                          . ,(funcall bufferlo-frame-geometry-function tbm-frame))
                         (bufferlo--tbms . ,tbm-names))))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -722,13 +722,13 @@ string, FACE is the face for STR."
     (let* ((fbm (frame-parameter nil 'bufferlo-bookmark-frame-name))
            (tbm (alist-get 'bufferlo-bookmark-tab-name (tab-bar--current-tab-find (frame-parameter nil 'tabs))))
            (abm (or fbm tbm ""))
-           (sess-active (> (length bufferlo--active-sets) 0))
+           (set-active (> (length bufferlo--active-sets) 0))
            (maybe-space (if (display-graphic-p) "" " "))) ; tty rendering can be off for Ⓕ Ⓣ
       (concat
        (bufferlo--mode-line-format-helper abm bufferlo-mode-line-prefix 'bufferlo-mode-line-face)
        (when bufferlo-mode-line-left-prefix
          (bufferlo--mode-line-format-helper abm bufferlo-mode-line-left-prefix 'bufferlo-mode-line-face))
-       (when sess-active
+       (when set-active
          (bufferlo--mode-line-format-helper abm bufferlo-mode-line-set-active-prefix 'bufferlo-mode-line-set-face))
        (when fbm
          (bufferlo--mode-line-format-helper
@@ -2746,11 +2746,11 @@ throwing away the old one."
     (let* ((abms (bufferlo--active-bookmarks))
            (abm-names (mapcar #'car abms))
            (abm-names-to-save))
-      (dolist (sess-name comps)
+      (dolist (set-name comps)
         (setq abm-names-to-save
               (append abm-names-to-save
                       (seq-intersection
-                       (alist-get 'bufferlo-bookmark-names (assoc sess-name bufferlo--active-sets))
+                       (alist-get 'bufferlo-bookmark-names (assoc set-name bufferlo--active-sets))
                        abm-names))))
       (setq abm-names-to-save (seq-uniq abm-names-to-save))
       (bufferlo--bookmarks-save abm-names-to-save abms))))
@@ -2792,11 +2792,11 @@ This closes their associated bookmarks and kills their buffers."
     (let* ((abms (bufferlo--active-bookmarks))
            (abm-names (mapcar #'car abms))
            (abm-names-to-close))
-      (dolist (sess-name comps)
+      (dolist (set-name comps)
         (setq abm-names-to-close
               (append abm-names-to-close
                       (seq-intersection
-                       (alist-get 'bufferlo-bookmark-names (assoc sess-name bufferlo--active-sets))
+                       (alist-get 'bufferlo-bookmark-names (assoc set-name bufferlo--active-sets))
                        abm-names))))
       (setq abm-names-to-close (seq-uniq abm-names-to-close))
       (bufferlo--close-active-bookmarks abm-names-to-close abms)

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2409,7 +2409,11 @@ Geometry set for FRAME or the current frame, if nil."
     (when (and .left .top .width .height) ; defensive in case geometry stored from a tty
       (set-frame-position nil .left .top)
       (sit-for 0 t)
-      (set-frame-size nil .width .height 'pixelwise)
+      ;; Clamp frame size restored from a larger display
+      (set-frame-size nil
+                      (min .width (display-pixel-width))
+                      (min .height (display-pixel-height))
+                      'pixelwise)
       (sit-for 0))))
 
 (defvar bufferlo--active-sets nil

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1918,45 +1918,19 @@ The parameters OTHER-WINDOW-P NOSELECT SHRINK are passed to `ibuffer'."
     (ibuffer other-window-p name '((bufferlo-orphan-buffers . nil))
              noselect shrink)))
 
-(eval-when-compile
-  (if (< emacs-major-version 31)
-      (define-ibuffer-op ibuffer-do-bufferlo-remove ()
-        "Remove marked buffers from bufferlo's local buffer list."
-        (
-         :active-opstring "remove from bufferlo locals" ; prompt
-         :opstring "removed from bufferlo locals:" ; success
-         :modifier-p t
-         :dangerous t
-         :complex t
-         :after (ibuffer-update nil t)
-         )
-        (when bufferlo-mode
-          (bufferlo-remove buf)
-          t))
-
-    (defun bufferlo--ibuffer-do-bufferlo-remove-prompt (op)
-      "`ibuffer' prompt helper for OP."
-      (let ((bookmark-name (bufferlo--current-bookmark-name)))
-        (format "%s from %slocals:" op
-                (if bookmark-name
-                    (format "bufferlo bookmark \"%s\" " bookmark-name)
-                  ""))))
-
-    (define-ibuffer-op ibuffer-do-bufferlo-remove ()
-      "Remove marked buffers from bufferlo\'s local buffer list."
-      (
-       :active-opstring (lambda ()
-                        (bufferlo--ibuffer-do-bufferlo-remove-prompt "remove"))
-       :opstring (lambda ()
-                 (bufferlo--ibuffer-do-bufferlo-remove-prompt "removed"))
-       :modifier-p t
-       :dangerous t
-       :complex t
-       :after (ibuffer-update nil t)
-       )
-      (when bufferlo-mode
-        (bufferlo-remove buf)
-        t))))
+(define-ibuffer-op ibuffer-do-bufferlo-remove ()
+  "Remove marked buffers from bufferlo's local buffer list."
+  (
+   :active-opstring "remove from bufferlo locals" ; prompt
+   :opstring "removed from bufferlo locals:" ; success
+   :modifier-p t
+   :dangerous t
+   :complex t
+   :after (ibuffer-update nil t)
+   )
+  (when bufferlo-mode
+    (bufferlo-remove buf)
+    t))
 
 (when bufferlo-ibuffer-bind-keys
   (define-key ibuffer-mode-map "-" #'ibuffer-do-bufferlo-remove))
@@ -2132,7 +2106,7 @@ local buffer list to use.  If it is nil, the current frame is used."
     (seq-union buffers-excl buffers-incl)))
 
 (defun bufferlo--bookmark-get-for-buffers-in-tab (buffers)
-  "Get bookmarks for all buffers of the selected tab in FRAME."
+  "Get bookmarks for all BUFFERS of the selected tab in FRAME."
   (seq-filter #'identity
               (mapcar #'bufferlo--bookmark-get-for-buffer
                       buffers)))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -3179,7 +3179,7 @@ This reuses the current tab even if
   (bufferlo--warn)
   (if-let* ((bm (alist-get 'bufferlo-bookmark-tab-name
                            (cdr (bufferlo--current-tab)))))
-      ;; On reload, always resue the existing tab (don't make a new one)
+      ;; On reload, always reuse the existing tab (don't make a new one)
       (let ((bufferlo-bookmark-tab-replace-policy 'replace)
             ;; The bookmark is detected as a duplicate bookmark, allow it here
             (bufferlo-bookmark-tab-duplicate-policy 'allow))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1937,19 +1937,46 @@ The parameters OTHER-WINDOW-P NOSELECT SHRINK are passed to `ibuffer'."
     (ibuffer other-window-p name '((bufferlo-orphan-buffers . nil))
              noselect shrink)))
 
-(define-ibuffer-op ibuffer-do-bufferlo-remove ()
-  "Remove marked buffers from bufferlo's local buffer list."
-  (
-   :active-opstring "remove from bufferlo locals" ; prompt
-   :opstring "removed from bufferlo locals:" ; success
-   :modifier-p t
-   :dangerous t
-   :complex t
-   :after (ibuffer-update nil t)
-   )
-  (when bufferlo-mode
-    (bufferlo-remove buf)
-    t))
+;; Below allows both old and new define-ibuffer-op macros to coexist.
+(defmacro bufferlo--ibuffer-do-wrapper ()
+  (if (< emacs-major-version 31)
+      '(define-ibuffer-op ibuffer-do-bufferlo-remove ()
+         "Remove marked buffers from bufferlo's local buffer list."
+         (
+          :active-opstring "remove from bufferlo locals"
+          :opstring "removed from bufferlo locals:"
+          :modifier-p t
+          :dangerous t
+          :complex t
+          :after (ibuffer-update nil t)
+          )
+         (when bufferlo-mode
+           (bufferlo-remove buf)
+           t))
+
+    '(defun bufferlo--ibuffer-do-bufferlo-remove-prompt (op)
+       "`ibuffer' prompt helper for OP."
+       (let ((bookmark-name (bufferlo--current-bookmark-name)))
+         (format "%s from %slocals:" op
+                 (if bookmark-name
+                     (format "bufferlo bookmark \"%s\" " bookmark-name)
+                   ""))))
+
+    '(define-ibuffer-op ibuffer-do-bufferlo-remove ()
+       "Remove marked buffers from bufferlo's local buffer list."
+       (
+        :active-opstring (lambda () (bufferlo--ibuffer-do-bufferlo-remove-prompt "remove"))
+        :opstring (lambda () (bufferlo--ibuffer-do-bufferlo-remove-prompt "removed"))
+        :modifier-p t
+        :dangerous t
+        :complex t
+        :after (ibuffer-update nil t)
+        )
+       (when bufferlo-mode
+         (bufferlo-remove buf)
+         t))
+    ))
+(bufferlo--ibuffer-do-wrapper)
 
 (when bufferlo-ibuffer-bind-keys
   (define-key ibuffer-mode-map "-" #'ibuffer-do-bufferlo-remove))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2484,73 +2484,72 @@ the message after successfully restoring the bookmark."
          (active-bookmark-names (seq-intersection bufferlo-bookmark-names abm-names)))
     (if (assoc bookmark-name bufferlo--active-sets)
         (message "Bufferlo set %s is already active" bookmark-name)
-      (if (> (length active-bookmark-names) 0)
-          (message "Close or clear active bufferlo bookmarks: %s" active-bookmark-names)
-        (let ((tabsets-str (bookmark-prop-get bookmark-record 'bufferlo-tabsets))
-              (tabsets))
-          (if (not (readablep tabsets-str))
-              (message "Bufferlo bookmark set %s: unreadable tabsets" bookmark-name)
-            (setq tabsets (car (read-from-string tabsets-str)))
-            (when tabsets ; could be readable and nil
-              (let ((first-tab-frame t))
-                (dolist (tab-group tabsets)
-                  (when (or (not first-tab-frame)
-                            (and first-tab-frame (not bufferlo-set-restore-tabs-reuse-init-frame)))
-                    (with-temp-buffer
-                      (select-frame (make-frame))))
-                  ;; (lower-frame) ; attempt to reduce visual flashing
-                  (when-let* ((fg (alist-get 'bufferlo--frame-geometry tab-group)))
-                    (when (and
-                           (display-graphic-p)
-                           (memq bufferlo-set-restore-geometry-policy '(all tab-frames))
-                           (or (not first-tab-frame)
-                               (and first-tab-frame (eq bufferlo-set-restore-tabs-reuse-init-frame 'reuse-reset-geometry))))
-                      (bufferlo--set-frame-geometry fg)))
-                  (when-let* ((tbm-names (alist-get 'bufferlo--tbms tab-group)))
-                    (let ((bufferlo-bookmark-tab-replace-policy 'replace) ; we handle making tabs in this loop
-                          (tab-bar-new-tab-choice t)
-                          (first-tab (or
-                                      (not first-tab-frame)
-                                      (and first-tab-frame (not bufferlo-set-restore-tabs-reuse-init-frame)))))
-                      (dolist (tbm-name tbm-names)
-                        (unless first-tab
-                          (tab-bar-new-tab-to))
-                        (bufferlo--bookmark-jump tbm-name)
-                        (setq first-tab nil))))
-                  (setq first-tab-frame nil))
-                (raise-frame)))))
-        (let ((frameset-str (bookmark-prop-get bookmark-record 'bufferlo-frameset))
-              (frameset))
-          (if (not (readablep frameset-str))
-              (message "Bufferlo bookmark set %s: unreadable frameset" bookmark-name)
-            (setq frameset (car (read-from-string frameset-str)))
-            (if (and frameset (not (frameset-valid-p frameset)))
-                (message "Bufferlo bookmark set %s: invalid frameset" bookmark-name)
-              (when frameset ; could be readable and nil
-                (funcall bufferlo-frameset-restore-function frameset)
-                (dolist (frame (frame-list))
-                  (with-selected-frame frame
-                    (when (frame-parameter nil 'bufferlo--frame-to-restore)
-                      ;; (lower-frame) ; attempt to reduce visual flashing
-                      (when-let* ((fbm-name (frame-parameter nil 'bufferlo-bookmark-frame-name)))
-                        (let ((bufferlo-bookmark-frame-load-make-frame nil)
-                              (bufferlo-bookmark-frame-duplicate-policy 'allow)
-                              (bufferlo-bookmark-frame-load-policy 'replace-frame-adopt-loaded-bookmark)
-                              (bufferlo--bookmark-handler-no-message t))
-                          (bufferlo--bookmark-jump fbm-name))
-                        (when (and
-                               (display-graphic-p frame)
-                               (memq bufferlo-set-restore-geometry-policy '(all frames)))
-                          (when-let* ((fg (frame-parameter nil 'bufferlo--frame-geometry)))
-                            (bufferlo--set-frame-geometry fg)))
-                        (set-frame-parameter nil 'bufferlo--frame-to-restore nil))
-                      (raise-frame))))))
-            (push
-             `(,bookmark-name (bufferlo-bookmark-names . ,bufferlo-bookmark-names))
-             bufferlo--active-sets)
-            (unless (or no-message bufferlo--bookmark-handler-no-message)
-              (message "Restored bufferlo bookmark set %s %s"
-                       bookmark-name bufferlo-bookmark-names))))))))
+      (message "Close or clear active bufferlo bookmarks: %s" active-bookmark-names)
+      (let ((tabsets-str (bookmark-prop-get bookmark-record 'bufferlo-tabsets))
+            (tabsets))
+        (if (not (readablep tabsets-str))
+            (message "Bufferlo bookmark set %s: unreadable tabsets" bookmark-name)
+          (setq tabsets (car (read-from-string tabsets-str)))
+          (when tabsets ; could be readable and nil
+            (let ((first-tab-frame t))
+              (dolist (tab-group tabsets)
+                (when (or (not first-tab-frame)
+                          (and first-tab-frame (not bufferlo-set-restore-tabs-reuse-init-frame)))
+                  (with-temp-buffer
+                    (select-frame (make-frame))))
+                ;; (lower-frame) ; attempt to reduce visual flashing
+                (when-let* ((fg (alist-get 'bufferlo--frame-geometry tab-group)))
+                  (when (and
+                         (display-graphic-p)
+                         (memq bufferlo-set-restore-geometry-policy '(all tab-frames))
+                         (or (not first-tab-frame)
+                             (and first-tab-frame (eq bufferlo-set-restore-tabs-reuse-init-frame 'reuse-reset-geometry))))
+                    (bufferlo--set-frame-geometry fg)))
+                (when-let* ((tbm-names (alist-get 'bufferlo--tbms tab-group)))
+                  (let ((bufferlo-bookmark-tab-replace-policy 'replace) ; we handle making tabs in this loop
+                        (tab-bar-new-tab-choice t)
+                        (first-tab (or
+                                    (not first-tab-frame)
+                                    (and first-tab-frame (not bufferlo-set-restore-tabs-reuse-init-frame)))))
+                    (dolist (tbm-name tbm-names)
+                      (unless first-tab
+                        (tab-bar-new-tab-to))
+                      (bufferlo--bookmark-jump tbm-name)
+                      (setq first-tab nil))))
+                (setq first-tab-frame nil))
+              (raise-frame)))))
+      (let ((frameset-str (bookmark-prop-get bookmark-record 'bufferlo-frameset))
+            (frameset))
+        (if (not (readablep frameset-str))
+            (message "Bufferlo bookmark set %s: unreadable frameset" bookmark-name)
+          (setq frameset (car (read-from-string frameset-str)))
+          (if (and frameset (not (frameset-valid-p frameset)))
+              (message "Bufferlo bookmark set %s: invalid frameset" bookmark-name)
+            (when frameset ; could be readable and nil
+              (funcall bufferlo-frameset-restore-function frameset)
+              (dolist (frame (frame-list))
+                (with-selected-frame frame
+                  (when (frame-parameter nil 'bufferlo--frame-to-restore)
+                    ;; (lower-frame) ; attempt to reduce visual flashing
+                    (when-let* ((fbm-name (frame-parameter nil 'bufferlo-bookmark-frame-name)))
+                      (let ((bufferlo-bookmark-frame-load-make-frame nil)
+                            (bufferlo-bookmark-frame-duplicate-policy 'allow)
+                            (bufferlo-bookmark-frame-load-policy 'replace-frame-adopt-loaded-bookmark)
+                            (bufferlo--bookmark-handler-no-message t))
+                        (bufferlo--bookmark-jump fbm-name))
+                      (when (and
+                             (display-graphic-p frame)
+                             (memq bufferlo-set-restore-geometry-policy '(all frames)))
+                        (when-let* ((fg (frame-parameter nil 'bufferlo--frame-geometry)))
+                          (bufferlo--set-frame-geometry fg)))
+                      (set-frame-parameter nil 'bufferlo--frame-to-restore nil))
+                    (raise-frame))))))
+          (push
+           `(,bookmark-name (bufferlo-bookmark-names . ,bufferlo-bookmark-names))
+           bufferlo--active-sets)
+          (unless (or no-message bufferlo--bookmark-handler-no-message)
+            (message "Restored bufferlo bookmark set %s %s"
+                     bookmark-name bufferlo-bookmark-names)))))))
 
 (put #'bufferlo--bookmark-set-handler 'bookmark-handler-type "B-Set") ; short name here as bookmark-bmenu-list hard codes width of 8 chars
 

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -393,12 +393,11 @@ advance that prevent duplicate frame and tab bookmarks."
 (defcustom bufferlo-bookmarks-save-predicate-functions
   (list #'bufferlo-bookmarks-save-all-p)
   "Functions to filter active bufferlo bookmarks to save.
-These are applied when
-`bufferlo-bookmarks-auto-save-idle-interval' is > 0, or manually
-via `bufferlo-bookmarks-save'.  Functions are passed the bufferlo
-bookmark name and invoked until the first positive result.  Set to
-`#'bufferlo-bookmarks-save-all-p' to save all bookmarks or
-provide your own predicates (note: be sure to remove
+These are applied when `bufferlo-bookmarks-auto-save-interval' is > 0,
+or manually via `bufferlo-bookmarks-save'.  Functions are passed the
+bufferlo bookmark name and invoked until the first positive result.  Set
+to `#'bufferlo-bookmarks-save-all-p' to save all bookmarks or provide
+your own predicates (note: be sure to remove
 `#'bufferlo-bookmarks-save-all-p' from the list)."
   :type 'hook)
 
@@ -523,7 +522,7 @@ frame bookmark is a collection of tab bookmarks."
 
 (defvar bufferlo--bookmarks-auto-save-timer nil
   "Timer to save bufferlo bookmarks.
-This is controlled by `bufferlo-bookmarks-auto-save-idle-interval'.")
+This is controlled by `bufferlo-bookmarks-auto-save-interval'.")
 
 (defun bufferlo--bookmarks-auto-save-timer-maybe-cancel ()
   "Cancel and clear the bufferlo bookmark auto-save timer, if set."
@@ -531,19 +530,20 @@ This is controlled by `bufferlo-bookmarks-auto-save-idle-interval'.")
     (cancel-timer bufferlo--bookmarks-auto-save-timer))
   (setq bufferlo--bookmarks-auto-save-timer nil))
 
-(defvar bufferlo-bookmarks-auto-save-idle-interval) ; byte compiler
+(defvar bufferlo-bookmarks-auto-save-interval) ; byte compiler
 (defun bufferlo--bookmarks-auto-save-timer-maybe-start ()
   "Start the bufferlo auto-save bookmarks timer, if needed."
   (bufferlo--bookmarks-auto-save-timer-maybe-cancel)
-  (when (> bufferlo-bookmarks-auto-save-idle-interval 0)
+  (when (and (integerp bufferlo-bookmarks-auto-save-interval)
+             (> bufferlo-bookmarks-auto-save-interval 0))
     (setq bufferlo--bookmarks-auto-save-timer
-          (run-with-idle-timer
-           bufferlo-bookmarks-auto-save-idle-interval
-           bufferlo-bookmarks-auto-save-idle-interval
+          (run-with-timer
+           bufferlo-bookmarks-auto-save-interval
+           bufferlo-bookmarks-auto-save-interval
            #'bufferlo-bookmarks-save))))
 
-(defcustom bufferlo-bookmarks-auto-save-idle-interval 0
-  "Save bufferlo bookmarks when Emacs has been idle this many seconds.
+(defcustom bufferlo-bookmarks-auto-save-interval 0
+  "Save bufferlo bookmarks every interval of this many seconds.
 Set to 0 to disable the timer.  Units are whole integer seconds."
   :type 'natnum
   :set (lambda (sym val)
@@ -3422,23 +3422,22 @@ Specify NO-MESSAGE to inhibit the bookmark save status message."
 
 (defun bufferlo-bookmarks-save (&optional all)
   "Save active bufferlo bookmarks.
-This is invoked via an optional idle timer which runs according
-to `bufferlo-bookmarks-auto-save-idle-interval', or and is
-optionally invoked at Emacs exit.
+This is invoked via an optional timer which runs according to
+`bufferlo-bookmarks-auto-save-interval', or and is optionally invoked at
+Emacs exit.
 
-You may invoke this manually at any time to save active
-bookmarks; however, doing so does not reset the save interval
-timer.
+You may invoke this manually at any time to save active bookmarks;
+however, doing so does not reset the save interval timer.
 
 Each bookmark is filtered according to
 `bufferlo-bookmarks-save-predicate-functions'.
 
-Specify ALL to ignore the predicates and save every active
-bufferlo bookmark or use a prefix argument across ALL frames,
-overriding `bufferlo-bookmarks-save-frame-policy'.
+Specify ALL to ignore the predicates and save every active bufferlo
+bookmark or use a prefix argument across ALL frames, overriding
+`bufferlo-bookmarks-save-frame-policy'.
 
-Note: if there are duplicate active bufferlo bookmarks, the last
-one to be saved will take precedence.
+Note: If there are duplicate active bufferlo bookmarks, the last one to
+be saved will take precedence.
 
 Duplicate bookmarks are handled according to
 `bufferlo-bookmarks-save-duplicates-policy'."

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1948,7 +1948,7 @@ FRAME specifies the frame; the default value of nil selects the current frame."
                  (setf (cadr bc) (cdr replace)))))))))
 
 (defun bufferlo--bookmark-get-duplicate-policy (bookmark-name thing default-policy mode)
-  "Get the duplicate policy for THING bookmarks.
+  "Get the duplicate policy for THING BOOKMARK-NAME.
 THING should be either \"frame\" or \"tab\".
 Ask the user if DEFAULT-POLICY is set to \\='prompt.
 MODE is either \\='load or \\='save, depending on the invoking action.

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1947,7 +1947,7 @@ FRAME specifies the frame; the default value of nil selects the current frame."
                (when-let* ((replace (assoc (cadr bc) replace-alist)))
                  (setf (cadr bc) (cdr replace)))))))))
 
-(defun bufferlo--bookmark-get-duplicate-policy (thing default-policy mode)
+(defun bufferlo--bookmark-get-duplicate-policy (bookmark-name thing default-policy mode)
   "Get the duplicate policy for THING bookmarks.
 THING should be either \"frame\" or \"tab\".
 Ask the user if DEFAULT-POLICY is set to \\='prompt.
@@ -1958,8 +1958,9 @@ This functions throws :abort when the user quits."
     (pcase (let ((read-answer-short t))
              (with-local-quit
                (read-answer
-                (format "%s bookmark name already active: Allow, %s, Raise existing "
+                (format "%s bookmark name \"%s\" already active: Allow, %s, Raise existing "
                         (capitalize thing)
+                        bookmark-name
                         (if (eq mode 'save)
                             "Clear other bookmark"
                           "Clear bookmark after loading"))
@@ -2043,7 +2044,7 @@ this bookmark is embedded in a frame bookmark."
       ;; Bookmark already loaded in another tab?
       (when abm
         (let ((duplicate-policy (bufferlo--bookmark-get-duplicate-policy
-                                 "tab" bufferlo-bookmark-tab-duplicate-policy 'load)))
+                                 bookmark-name "tab" bufferlo-bookmark-tab-duplicate-policy 'load)))
           (pcase duplicate-policy
             ('allow)
             ('clear
@@ -2187,7 +2188,7 @@ the message after successfully restoring the bookmark."
       ;; Bookmark already loaded in another frame?
       (when abm
         (setq duplicate-policy (bufferlo--bookmark-get-duplicate-policy
-                                "frame" bufferlo-bookmark-frame-duplicate-policy 'load))
+                                bookmark-name "frame" bufferlo-bookmark-frame-duplicate-policy 'load))
         (when (eq duplicate-policy 'raise)
           (bufferlo--bookmark-raise abm)
           (throw :abort t)))
@@ -2483,7 +2484,7 @@ the message after successfully restoring the bookmark."
          (abm-names (mapcar #'car (bufferlo--active-bookmarks)))
          (active-bookmark-names (seq-intersection bufferlo-bookmark-names abm-names)))
     (if (assoc bookmark-name bufferlo--active-sets)
-        (message "Bufferlo set %s is already active" bookmark-name)
+        (message "Bufferlo set \"%s\" is already active" bookmark-name)
       (message "Close or clear active bufferlo bookmarks: %s" active-bookmark-names)
       (let ((tabsets-str (bookmark-prop-get bookmark-record 'bufferlo-tabsets))
             (tabsets))
@@ -2779,7 +2780,7 @@ is not recommended."
         ;; Bookmark already loaded in another tab?
         (when abm
           (pcase (bufferlo--bookmark-get-duplicate-policy
-                  "tab" bufferlo-bookmark-tab-duplicate-policy 'save)
+                  name "tab" bufferlo-bookmark-tab-duplicate-policy 'save)
             ('allow)
             ('clear
              (bufferlo--clear-tab-bookmarks-by-name name))
@@ -2915,7 +2916,7 @@ but is not recommended."
         ;; Bookmark already loaded in another frame?
         (when abm
           (pcase (bufferlo--bookmark-get-duplicate-policy
-                  "frame" bufferlo-bookmark-frame-duplicate-policy 'save)
+                  name "frame" bufferlo-bookmark-frame-duplicate-policy 'save)
             ('allow)
             ('clear
              (bufferlo--clear-frame-bookmarks-by-name name))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2336,6 +2336,7 @@ this bookmark is embedded in a frame bookmark."
 
 ;; We use a short name here as bookmark-bmenu-list hard codes width of 8 chars
 (put #'bufferlo--bookmark-tab-handler 'bookmark-handler-type "B-Tab")
+(put #'bufferlo--bookmark-tab-handler 'bookmark-inhibit 'insert)
 
 (defun bufferlo--bookmark-frame-make (&optional frame)
   "Make a bufferlo frame bookmark.
@@ -2506,6 +2507,7 @@ the message after successfully restoring the bookmark."
 
 ;; We use a short name here as bookmark-bmenu-list hard codes width of 8 chars
 (put #'bufferlo--bookmark-frame-handler 'bookmark-handler-type "B-Frame")
+(put #'bufferlo--bookmark-frame-handler 'bookmark-inhibit 'insert)
 
 (defun bufferlo--bookmark-set-location (bookmark-name-or-record &optional location)
   "Set the location of BOOKMARK-NAME-OR-RECORD to LOCATION or \\=\"\", if nil."
@@ -2843,6 +2845,7 @@ the message after successfully restoring the bookmark."
 
 ;; We use a short name here as bookmark-bmenu-list hard codes width of 8 chars
 (put #'bufferlo--bookmark-set-handler 'bookmark-handler-type "B-Set")
+(put #'bufferlo--bookmark-set-handler 'bookmark-inhibit 'insert)
 
 (defun bufferlo--set-save (bookmark-name active-bookmark-names active-bookmarks &optional no-overwrite)
   "Save a bufferlo bookmark set for the specified active bookmarks.

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -3824,7 +3824,7 @@ raised."
 
 ;; DWIM convenience functions
 
-(defun bufferlo-bookmark-save-curr ()
+(defun bufferlo-bookmark-save-current ()
   "DWIM save current bufferlo bookmark.
 Save the current bufferlo frame bookmark or tab bookmark,
 prioritizing frame bookmarks over tab bookmarks, should both
@@ -3842,7 +3842,7 @@ save a new bookmark."
         (bufferlo--bookmark-tab-save bm)
       (message "No active bufferlo frame or tab bookmark to save."))))
 
-(defun bufferlo-bookmark-load-curr ()
+(defun bufferlo-bookmark-load-current ()
   "DWIM reload current bufferlo bookmark.
 Load the current bufferlo frame bookmark or tab bookmark,
 prioritizing frame bookmarks over tab bookmarks, should both
@@ -3870,7 +3870,7 @@ load a new bookmark."
           (bufferlo-bookmark-tab-load bm))
       (message "No active bufferlo frame or tab bookmark to load."))))
 
-(defun bufferlo-bookmark-close-curr ()
+(defun bufferlo-bookmark-close-current ()
   "DWIM close current bufferlo bookmark and kill its buffers.
 Close the current bufferlo frame bookmark or tab bookmark,
 prioritizing frame bookmarks over tab bookmarks, should both
@@ -3930,9 +3930,9 @@ OLDFN BOOKMARK-NAME BATCH"
 (defalias 'bufferlo-bms-save            'bufferlo-bookmarks-save-interactive)
 (defalias 'bufferlo-bms-close           'bufferlo-bookmarks-close-interactive)
 (defalias 'bufferlo-bm-raise            'bufferlo-bookmark-raise)
-(defalias 'bufferlo-bm-save             'bufferlo-bookmark-save-curr)
-(defalias 'bufferlo-bm-load             'bufferlo-bookmark-load-curr)
-(defalias 'bufferlo-bm-close            'bufferlo-bookmark-close-curr)
+(defalias 'bufferlo-bm-save             'bufferlo-bookmark-save-current)
+(defalias 'bufferlo-bm-load             'bufferlo-bookmark-load-current)
+(defalias 'bufferlo-bm-close            'bufferlo-bookmark-close-current)
 (defalias 'bufferlo-bm-tab-save         'bufferlo-bookmark-tab-save)
 (defalias 'bufferlo-bm-tab-save-curr    'bufferlo-bookmark-tab-save-current)
 (defalias 'bufferlo-bm-tab-load         'bufferlo-bookmark-tab-load)

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2450,6 +2450,14 @@ the message after successfully restoring the bookmark."
          ;; of with-selected-frame
          (select-frame-set-input-focus frame)))
 
+      (unless (or new-frame-p pop-up-frames)
+        ;; Switch to the to-be-selected buffer in the current frame.
+        ;; This is a workaround for bookmark-jump if called with display-func
+        ;; set to something like pop-to-buffer-same-window (the default).
+        ;; Without this, the previously selected buffer will leak into the
+        ;; loaded frame bookmark.
+        (switch-to-buffer (window-buffer (frame-selected-window nil))))
+
       ;; Log message
       (unless (or no-message bufferlo--bookmark-handler-no-message)
         (message "Restored bufferlo frame bookmark%s%s"

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -146,8 +146,10 @@ hidden, and special buffers that can not normally be saved.
 without remorse including those with running processes such as
 `shell-mode' buffers."
   :type '(radio (const :tag "Retain modified buffers" retain-modified)
-                (const :tag "Retain modified buffers BUT kill buffers without file names" retain-modified-kill-without-file-name)
-                (const :tag "Kill modified buffers without prompting" kill-modified)
+                (const :tag "Retain modified buffers BUT kill buffers without file names"
+                       retain-modified-kill-without-file-name)
+                (const :tag "Kill modified buffers without prompting"
+                       kill-modified)
                 (const :tag "Default Emacs behavior (will prompt)" nil)))
 
 (defcustom bufferlo-bookmark-inhibit-bookmark-point nil
@@ -170,7 +172,8 @@ This is a list of regular expressions to filter buffer names."
 Set to \\='restore-geometry to restore the frame geometry to that
 when it was last saved."
   :type '(radio (const :tag "Make a new frame" t)
-                (const :tag "Make a new frame and restore its geometry" restore-geometry)
+                (const :tag "Make a new frame and restore its geometry"
+                       restore-geometry)
                 (const :tag "Reuse the current frame" nil)))
 
 (defcustom bufferlo-delete-frame-kill-buffers-prompt nil
@@ -255,8 +258,10 @@ loading is not overridden with a prefix argument that suppresses
 making a new frame."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Disallow" disallow-replace)
-                (const :tag "Replace frame, retain current bookmark name" replace-frame-retain-current-bookmark)
-                (const :tag "Replace frame, adopt loaded bookmark name" replace-frame-adopt-loaded-bookmark)
+                (const :tag "Replace frame, retain current bookmark name"
+                       replace-frame-retain-current-bookmark)
+                (const :tag "Replace frame, adopt loaded bookmark name"
+                       replace-frame-adopt-loaded-bookmark)
                 (const :tag "Merge" merge)))
 
 (defcustom bufferlo-bookmark-frame-duplicate-policy 'prompt
@@ -380,7 +385,8 @@ advance that prevent duplicate frame and tab bookmarks."
                 (const :tag "Other frames" other)
                 (const :tag "All frames" all)))
 
-(defcustom bufferlo-bookmarks-save-predicate-functions (list #'bufferlo-bookmarks-save-all-p)
+(defcustom bufferlo-bookmarks-save-predicate-functions
+  (list #'bufferlo-bookmarks-save-all-p)
   "Functions to filter active bufferlo bookmarks to save.
 These are applied when
 `bufferlo-bookmarks-auto-save-idle-interval' is > 0, or manually
@@ -601,14 +607,15 @@ packages that do, and you want to ensure they are filtered in
 advance of restoring bufferlo framesets."
   :type '(repeat symbol))
 
-(defcustom bufferlo-frameset-restore-function #'bufferlo-frameset-restore-default
+(defcustom bufferlo-frameset-restore-function#'bufferlo-frameset-restore-default
   "Function to restore a frameset, which see `frameset-restore'.
 It defaults to `bufferlo-frameset-restore-default'.
 
 The function accepts a single parameter, the `frameset' to restore."
   :type 'function)
 
-(defcustom bufferlo-frameset-restore-parameters-function #'bufferlo-frameset-restore-parameters-default
+(defcustom bufferlo-frameset-restore-parameters-function
+  #'bufferlo-frameset-restore-parameters-default
   "Function to create parameters for `frameset-restore', which see.
 
 The function should create a plist of the form:
@@ -623,7 +630,8 @@ where each property is as documented by `frameset-restore'.
 It defaults to `bufferlo-frameset-restore-parameters-default'."
   :type 'function)
 
-(defcustom bufferlo-frame-geometry-function #'bufferlo-frame-geometry-default
+(defcustom bufferlo-frame-geometry-function
+  #'bufferlo-frame-geometry-default
   "Function to produce a bufferlo-frame-geometry alist.
 It defaults to `bufferlo-frame-geometry-default'.
 
@@ -635,7 +643,8 @@ Replace this function with your own if the default produces
 suboptimal results for your platform."
   :type 'function)
 
-(defcustom bufferlo-set-frame-geometry-function #'bufferlo-set-frame-geometry-default
+(defcustom bufferlo-set-frame-geometry-function
+  #'bufferlo-set-frame-geometry-default
   "Function to set frame geometry based on bufferlo-frame-geometry alist.
 It defaults to `bufferlo-set-frame-geometry-default', which see for
 parameters.
@@ -705,26 +714,35 @@ string, FACE is the face for STR."
   "Bufferlo mode-line format to display the current active frame or tab bookmark."
   (when bufferlo-mode
     (let* ((fbm (frame-parameter nil 'bufferlo-bookmark-frame-name))
-           (tbm (alist-get 'bufferlo-bookmark-tab-name (tab-bar--current-tab-find (frame-parameter nil 'tabs))))
+           (tbm (alist-get 'bufferlo-bookmark-tab-name
+                           (tab-bar--current-tab-find
+                            (frame-parameter nil 'tabs))))
            (abm (or fbm tbm ""))
            (set-active (> (length bufferlo--active-sets) 0))
-           (maybe-space (if (display-graphic-p) "" " "))) ; tty rendering can be off for Ⓕ Ⓣ
+           ; tty rendering can be off for some characters, e.g., Ⓕ Ⓣ
+           (maybe-space (if (display-graphic-p) "" " ")))
       (concat
-       (bufferlo--mode-line-format-helper abm bufferlo-mode-line-prefix 'bufferlo-mode-line-face)
+       (bufferlo--mode-line-format-helper abm bufferlo-mode-line-prefix
+                                          'bufferlo-mode-line-face)
        (when bufferlo-mode-line-left-prefix
-         (bufferlo--mode-line-format-helper abm bufferlo-mode-line-left-prefix 'bufferlo-mode-line-face))
+         (bufferlo--mode-line-format-helper
+          abm bufferlo-mode-line-left-prefix 'bufferlo-mode-line-face))
        (when set-active
-         (bufferlo--mode-line-format-helper abm bufferlo-mode-line-set-active-prefix 'bufferlo-mode-line-set-face))
+         (bufferlo--mode-line-format-helper
+          abm bufferlo-mode-line-set-active-prefix 'bufferlo-mode-line-set-face))
        (when fbm
          (bufferlo--mode-line-format-helper
           abm
-          (concat bufferlo-mode-line-frame-prefix maybe-space fbm) 'bufferlo-mode-line-frame-bookmark-face))
+          (concat bufferlo-mode-line-frame-prefix maybe-space fbm)
+          'bufferlo-mode-line-frame-bookmark-face))
        (when tbm
          (bufferlo--mode-line-format-helper
           abm
-          (concat bufferlo-mode-line-tab-prefix maybe-space tbm) 'bufferlo-mode-line-tab-bookmark-face))
+          (concat bufferlo-mode-line-tab-prefix maybe-space tbm)
+          'bufferlo-mode-line-tab-bookmark-face))
        (when bufferlo-mode-line-right-suffix
-         (bufferlo--mode-line-format-helper abm bufferlo-mode-line-right-suffix 'bufferlo-mode-line-face))))))
+         (bufferlo--mode-line-format-helper
+          abm bufferlo-mode-line-right-suffix 'bufferlo-mode-line-face))))))
 
 (defcustom bufferlo-mode-line '(:eval (bufferlo-mode-line-format))
   "Bufferlo mode line definition."
@@ -756,7 +774,9 @@ string, FACE is the face for STR."
 
 (defun bufferlo--parse-command-line ()
   "Process bufferlo Emacs command-line arguments."
-  (when-let* ((pos (seq-position command-line-args bufferlo--command-line-noload-prefix #'string-equal)))
+  (when-let* ((pos (seq-position command-line-args
+                                 bufferlo--command-line-noload-prefix
+                                 #'string-equal)))
     (setq bufferlo--command-line-noload pos)
     (setq command-line-args (seq-remove-at-position command-line-args pos)))
   (when (file-exists-p (expand-file-name "bufferlo-noload" user-emacs-directory))
@@ -765,7 +785,9 @@ string, FACE is the face for STR."
 
 (defun -bufferlo--parse-command-line-test ()
   "Internal test function for command-line processing."
-  (let ((command-line-args (list "/usr/bin/emacs" "--name" "foobar" bufferlo--command-line-noload-prefix "-T" "title")))
+  (let ((command-line-args (list "/usr/bin/emacs" "--name" "foobar"
+                                 bufferlo--command-line-noload-prefix
+                                 "-T" "title")))
     (setq bufferlo--command-line-noload nil)
     (message "command-line-args=%s" command-line-args)
     (message "bufferlo--command-line-noload=%s" bufferlo--command-line-noload)
@@ -803,12 +825,15 @@ string, FACE is the face for STR."
         (when bufferlo-prefer-local-buffers
           (dolist (frame (frame-list))
             (bufferlo--set-buffer-predicate frame))
-          (add-hook 'after-make-frame-functions #'bufferlo--set-buffer-predicate))
+          (add-hook 'after-make-frame-functions
+                    #'bufferlo--set-buffer-predicate))
         (when (eq bufferlo-prefer-local-buffers 'tabs)
           (bufferlo--set-switch-to-prev-buffer-skip))
         ;; Include/exclude buffers
-        (add-hook 'after-make-frame-functions #'bufferlo--include-exclude-buffers)
-        (add-hook 'tab-bar-tab-post-open-functions #'bufferlo--tab-include-exclude-buffers)
+        (add-hook 'after-make-frame-functions
+                  #'bufferlo--include-exclude-buffers)
+        (add-hook 'tab-bar-tab-post-open-functions
+                  #'bufferlo--tab-include-exclude-buffers)
         ;; Save/restore local buffer list
         (advice-add #'window-state-get :around #'bufferlo--window-state-get)
         (advice-add #'window-state-put :after #'bufferlo--window-state-put)
@@ -818,14 +843,19 @@ string, FACE is the face for STR."
         (advice-add #'tab-bar-select-tab :around #'bufferlo--activate-force)
         ;; Clone & undelete frame
         (when (>= emacs-major-version 28)
-          (advice-add #'clone-frame :around #'bufferlo--clone-undelete-frame-advice))
+          (advice-add #'clone-frame :around
+                      #'bufferlo--clone-undelete-frame-advice))
         (when (>= emacs-major-version 29)
-          (advice-add #'undelete-frame :around #'bufferlo--clone-undelete-frame-advice))
+          (advice-add #'undelete-frame :around
+                      #'bufferlo--clone-undelete-frame-advice))
         ;; Undo close tab duplicate check
-        (advice-add #'tab-bar-undo-close-tab :around #'bufferlo--tab-bar-undo-close-tab-advice)
+        (advice-add #'tab-bar-undo-close-tab
+                    :around #'bufferlo--tab-bar-undo-close-tab-advice)
         ;; Switch-tab workaround
-        (advice-add #'tab-bar-select-tab :around #'bufferlo--clear-buffer-lists-activate)
-        (advice-add #'tab-bar--tab :after #'bufferlo--clear-buffer-lists)
+        (advice-add #'tab-bar-select-tab
+                    :around #'bufferlo--clear-buffer-lists-activate)
+        (advice-add #'tab-bar--tab
+                    :after #'bufferlo--clear-buffer-lists)
         ;; Set up bookmarks save timer
         (bufferlo--bookmarks-auto-save-timer-maybe-start)
         ;; kill-emacs-hook save bookmarks option
@@ -852,8 +882,10 @@ string, FACE is the face for STR."
       (bufferlo--reset-switch-to-prev-buffer-skip))
     (remove-hook 'after-make-frame-functions #'bufferlo--set-buffer-predicate)
     ;; Include/exclude buffers
-    (remove-hook 'after-make-frame-functions #'bufferlo--include-exclude-buffers)
-    (remove-hook 'tab-bar-tab-post-open-functions #'bufferlo--tab-include-exclude-buffers)
+    (remove-hook 'after-make-frame-functions
+                 #'bufferlo--include-exclude-buffers)
+    (remove-hook 'tab-bar-tab-post-open-functions
+                 #'bufferlo--tab-include-exclude-buffers)
     ;; Save/restore local buffer list
     (advice-remove #'window-state-get #'bufferlo--window-state-get)
     (advice-remove #'window-state-put #'bufferlo--window-state-put)
@@ -867,7 +899,8 @@ string, FACE is the face for STR."
     (when (>= emacs-major-version 29)
       (advice-remove #'undelete-frame #'bufferlo--clone-undelete-frame-advice))
     ;; Undo close tab duplicate check
-    (advice-remove #'tab-bar-undo-close-tab #'bufferlo--tab-bar-undo-close-tab-advice)
+    (advice-remove #'tab-bar-undo-close-tab
+                   #'bufferlo--tab-bar-undo-close-tab-advice)
     ;; Switch-tab workaround
     (advice-remove #'tab-bar-select-tab #'bufferlo--clear-buffer-lists-activate)
     (advice-remove #'tab-bar--tab #'bufferlo--clear-buffer-lists)
@@ -904,7 +937,8 @@ string, FACE is the face for STR."
                      (abm-names (mapcar #'car abms))
                      (current-bm-name (bufferlo--current-bookmark-name)))
                 (mapcar (lambda (abm-name)
-                          (vector abm-name `(bufferlo--bookmark-raise-by-name ,abm-name)
+                          (vector abm-name
+                                  `(bufferlo--bookmark-raise-by-name ,abm-name)
                                   :style 'radio
                                   :selected (equal abm-name current-bm-name)))
                         abm-names)))))
@@ -1095,7 +1129,8 @@ Includes hidden buffers."
 
 (defun bufferlo--reset-buffer-predicate (frame)
   "Reset the buffer predicate of FRAME if it is `bufferlo--buffer-predicate'."
-  (when (eq (frame-parameter frame 'buffer-predicate) #'bufferlo--buffer-predicate)
+  (when (eq (frame-parameter frame 'buffer-predicate)
+            #'bufferlo--buffer-predicate)
     (set-frame-parameter frame 'buffer-predicate nil)))
 
 (defun bufferlo--merge-regexp-list (regexp-list)
@@ -1261,7 +1296,10 @@ the advised functions. Honors `bufferlo-bookmark-frame-duplicate-policy'."
         (when
             (catch :abort
               (let ((duplicate-policy (bufferlo--bookmark-get-duplicate-policy
-                                       bookmark-name "frame" bufferlo-bookmark-frame-duplicate-policy 'undelete)))
+                                       bookmark-name
+                                       "frame"
+                                       bufferlo-bookmark-frame-duplicate-policy
+                                       'undelete)))
                 (pcase duplicate-policy
                   ('allow)
                   ('clear
@@ -1273,7 +1311,8 @@ the advised functions. Honors `bufferlo-bookmark-frame-duplicate-policy'."
                    (delete-frame)
                    (bufferlo--bookmark-raise abm)
                    (throw :raise t)))
-                (set-frame-parameter nil 'bufferlo-bookmark-frame-name bookmark-name))
+                (set-frame-parameter nil 'bufferlo-bookmark-frame-name
+                                     bookmark-name))
               (when msg
                 (message "Undelete frame bufferlo bookmark%s%s"
                          (if bookmark-name (format ": %s" bookmark-name) "")
@@ -1296,7 +1335,9 @@ the advised functions. Honors `bufferlo-bookmark-tab-duplicate-policy'."
         (when
             (catch :abort
               (let ((duplicate-policy (bufferlo--bookmark-get-duplicate-policy
-                                       bookmark-name "tab" bufferlo-bookmark-tab-duplicate-policy 'undelete)))
+                                       bookmark-name "tab"
+                                       bufferlo-bookmark-tab-duplicate-policy
+                                       'undelete)))
                 (pcase duplicate-policy
                   ('allow)
                   ('clear
@@ -1308,7 +1349,9 @@ the advised functions. Honors `bufferlo-bookmark-tab-duplicate-policy'."
                    (tab-bar-close-tab)
                    (bufferlo--bookmark-raise abm)
                    (throw :raise t)))
-                (setf (alist-get 'bufferlo-bookmark-tab-name (cdr current-tab)) bookmark-name))
+                (setf (alist-get 'bufferlo-bookmark-tab-name
+                                 (cdr current-tab))
+                      bookmark-name))
               (when msg
                 (message "Undo close tab bufferlo bookmark%s%s"
                          (if bookmark-name (format ": %s" bookmark-name) "")
@@ -1479,7 +1522,6 @@ argument INTERNAL-TOO is non-nil."
            (buffers (seq-filter
                      (lambda (b)
                        (not (and
-                             ;; (or internal-too (/= (aref (buffer-name b) 0) ?\s)) ; NOTE: this can cause null reference errors
                              (or internal-too
                                  (not (string-prefix-p " " (buffer-name b))))
                              (string-match-p exclude (buffer-name b)))))
@@ -1501,7 +1543,6 @@ Buffers matching `bufferlo-kill-buffers-exclude-filters' are never killed."
            (buffers (seq-filter
                      (lambda (b)
                        (not (and
-                             ;; (or internal-too (/= (aref (buffer-name b) 0) ?\s)) ; NOTE: this can cause null reference errors
                              (or internal-too
                                  (not (string-prefix-p " " (buffer-name b))))
                              (string-match-p exclude (buffer-name b)))))
@@ -1679,7 +1720,8 @@ If the buffer is already visible in a non-selected window, select it."
                           (bufferlo-buffer-list nil nil t))))
     (unless buffer
       (setq buffer (get-buffer-create
-                    (generate-new-buffer-name bufferlo-local-scratch-buffer-name)))
+                    (generate-new-buffer-name
+                     bufferlo-local-scratch-buffer-name)))
       (with-current-buffer buffer
         (when (eq major-mode 'fundamental-mode)
           (funcall (or bufferlo-local-scratch-buffer-initial-major-mode
@@ -1689,7 +1731,8 @@ If the buffer is already visible in a non-selected window, select it."
 
 (defun bufferlo-create-local-scratch-buffer ()
   "Create a local scratch buffer and return it."
-  (get-buffer-create (generate-new-buffer-name bufferlo-local-scratch-buffer-name)))
+  (get-buffer-create (generate-new-buffer-name
+                      bufferlo-local-scratch-buffer-name)))
 
 (defun bufferlo-switch-to-scratch-buffer (&optional frame)
   "Switch to the scratch buffer.
@@ -1749,13 +1792,13 @@ If the prefix argument is given, include all buffers."
   (bufferlo--warn)
   (display-buffer
    (let* ((old-buffer (current-buffer))
-          (name (or
-                 (seq-find (lambda (b)
-                             (string-match-p
-                              "\\`\\*Bufferlo Local Buffer List\\*\\(<[0-9]*>\\)?\\'"
-                              (buffer-name b)))
-                           (bufferlo-buffer-list))
-                 (generate-new-buffer-name "*Bufferlo Local Buffer List*")))
+          (name (or (seq-find
+                     (lambda (b)
+                       (string-match-p
+                        "\\`\\*Bufferlo Local Buffer List\\*\\(<[0-9]*>\\)?\\'"
+                        (buffer-name b)))
+                     (bufferlo-buffer-list))
+                    (generate-new-buffer-name "*Bufferlo Local Buffer List*")))
           (buffer (get-buffer-create name)))
      (with-current-buffer buffer
        (Buffer-menu-mode)
@@ -1763,7 +1806,8 @@ If the prefix argument is given, include all buffers."
        (setq Buffer-menu-files-only nil)
        (setq Buffer-menu-buffer-list #'bufferlo--local-buffer-list-this-frame)
        (setq Buffer-menu-filter-predicate nil)
-       (list-buffers--refresh #'bufferlo--local-buffer-list-this-frame old-buffer)
+       (list-buffers--refresh
+        #'bufferlo--local-buffer-list-this-frame old-buffer)
        (tabulated-list-print)
        (revert-buffer))
      buffer)))
@@ -1969,7 +2013,9 @@ In contrast to `bufferlo-anywhere-mode', this does not adhere to
         (bookmark-jump bookmark #'ignore)
         t)
     (progn
-      (message (delay-warning 'bufferlo (format "Error %S when jumping to bookmark %S" err bookmark)))
+      (message (delay-warning 'bufferlo
+                              (format "Error %S when jumping to bookmark %S"
+                                      err bookmark)))
       nil)))
 
 (defun bufferlo--bookmark-get-for-buffer (buffer)
@@ -1996,13 +2042,15 @@ In contrast to `bufferlo-anywhere-mode', this does not adhere to
                    (seq-remove
                     (lambda (buf)
                       (seq-filter
-                       (lambda (regexp) (string-match-p regexp (buffer-name buf)))
+                       (lambda (regexp) (string-match-p regexp
+                                                        (buffer-name buf)))
                        bufferlo-bookmark-buffers-exclude-filters))
                     buffers)
                    (seq-filter
                     (lambda (buf)
                       (seq-filter
-                       (lambda (regexp) (string-match-p regexp (buffer-name buf)))
+                       (lambda (regexp) (string-match-p regexp
+                                                        (buffer-name buf)))
                        bufferlo-bookmark-buffers-include-filters))
                     buffers))))
     buffers))
@@ -2179,7 +2227,8 @@ this bookmark is embedded in a frame bookmark."
       ;; Bookmark already loaded in another tab?
       (when abm
         (let ((duplicate-policy (bufferlo--bookmark-get-duplicate-policy
-                                 bookmark-name "tab" bufferlo-bookmark-tab-duplicate-policy 'load)))
+                                 bookmark-name "tab"
+                                 bufferlo-bookmark-tab-duplicate-policy 'load)))
           (pcase duplicate-policy
             ('allow)
             ('clear
@@ -2255,7 +2304,8 @@ this bookmark is embedded in a frame bookmark."
                  (if bookmark-name (format ": %s" bookmark-name) "")
                  (or msg ""))))))
 
-(put #'bufferlo--bookmark-tab-handler 'bookmark-handler-type "B-Tab") ; short name here as bookmark-bmenu-list hard codes width of 8 chars
+;; We use a short name here as bookmark-bmenu-list hard codes width of 8 chars
+(put #'bufferlo--bookmark-tab-handler 'bookmark-handler-type "B-Tab")
 
 (defun bufferlo--bookmark-frame-make (&optional frame)
   "Get the bufferlo frame bookmark.
@@ -2264,7 +2314,8 @@ FRAME specifies the frame; the default value of nil selects the current frame."
         (tabs nil))
     (dotimes (i (length (funcall tab-bar-tabs-function frame)))
       (tab-bar-select-tab (1+ i))
-      (let* ((curr (alist-get 'current-tab (funcall tab-bar-tabs-function frame)))
+      (let* ((curr (alist-get 'current-tab
+                              (funcall tab-bar-tabs-function frame)))
              (name (alist-get 'name curr))
              (explicit-name (alist-get 'explicit-name curr))
              (tbm (bufferlo--bookmark-tab-make frame)))
@@ -2275,7 +2326,8 @@ FRAME specifies the frame; the default value of nil selects the current frame."
     (tab-bar-select-tab orig-tab)
     `((tabs . ,(reverse tabs))
       (current . ,orig-tab)
-      (bufferlo--frame-geometry . ,(funcall bufferlo-frame-geometry-function (or frame (selected-frame))))
+      (bufferlo--frame-geometry . ,(funcall bufferlo-frame-geometry-function
+                                            (or frame (selected-frame))))
       (handler . ,#'bufferlo--bookmark-frame-handler))))
 
 (defun bufferlo--bookmark-frame-get-load-policy ()
@@ -2323,7 +2375,8 @@ the message after successfully restoring the bookmark."
       ;; Bookmark already loaded in another frame?
       (when abm
         (setq duplicate-policy (bufferlo--bookmark-get-duplicate-policy
-                                bookmark-name "frame" bufferlo-bookmark-frame-duplicate-policy 'load))
+                                bookmark-name "frame"
+                                bufferlo-bookmark-frame-duplicate-policy 'load))
         (when (eq duplicate-policy 'raise)
           (bufferlo--bookmark-raise abm)
           (throw :abort t)))
@@ -2339,7 +2392,8 @@ the message after successfully restoring the bookmark."
           (setq load-policy (bufferlo--bookmark-frame-get-load-policy))
           (pcase load-policy
             ('disallow-replace
-             (when (not (equal fbm bookmark-name)) ; allow reloads of existing bookmark
+             ;; Allow reloads of existing bookmark
+             (when (not (equal fbm bookmark-name))
                (unless no-message
                  (message "Frame already bookmarked as %s; not loaded." fbm))
                (throw :abort t)))
@@ -2352,18 +2406,21 @@ the message after successfully restoring the bookmark."
              (funcall msg-append (format "merged tabs from bookmark %s."
                                          bookmark-name))))))
 
-      ;; Do the real work with the target frame selected (current or newly created)
+      ;; Do the real work with the target frame selected
+      ;; (current or newly created)
       ;; NOTE: No :abort throws after this point
       (bufferlo--with-temp-buffer
        (let ((frame (if new-frame-p
                         (bufferlo--make-frame
-                         (eq bufferlo-bookmark-frame-load-make-frame 'restore-geometry))
+                         (eq bufferlo-bookmark-frame-load-make-frame
+                             'restore-geometry))
                       (selected-frame))))
          (with-selected-frame frame
            ;; Restore geometry
            (when (and new-frame-p
                       (display-graphic-p)
-                      (eq bufferlo-bookmark-frame-load-make-frame 'restore-geometry))
+                      (eq bufferlo-bookmark-frame-load-make-frame
+                          'restore-geometry))
              (when-let* ((fg (alist-get 'bufferlo--frame-geometry bookmark)))
                (funcall bufferlo-set-frame-geometry-function fg)))
 
@@ -2399,7 +2456,8 @@ the message after successfully restoring the bookmark."
 
            (set-frame-parameter nil 'bufferlo-bookmark-frame-name fbm))
 
-         ;; Select and raise the restored frame outside the context of with-selected-frame
+         ;; Select and raise the restored frame outside the context
+         ;; of with-selected-frame
          (select-frame-set-input-focus frame)))
 
       ;; Log message
@@ -2408,7 +2466,8 @@ the message after successfully restoring the bookmark."
                  (if bookmark-name (format ": %s" bookmark-name) "")
                  (or msg ""))))))
 
-(put #'bufferlo--bookmark-frame-handler 'bookmark-handler-type "B-Frame") ; short name here as bookmark-bmenu-list hard codes width of 8 chars
+;; We use a short name here as bookmark-bmenu-list hard codes width of 8 chars
+(put #'bufferlo--bookmark-frame-handler 'bookmark-handler-type "B-Frame")
 
 (defun bufferlo--bookmark-set-location (bookmark-name-or-record &optional location)
   "Set the location of BOOKMARK-NAME-OR-RECORD to LOCATION or \\=\"\", if nil."
@@ -2431,9 +2490,11 @@ CANDIDATES are the prompt options to select."
            candidates nil nil))
          (base-size (cdr (last comps))))
     (when base-size (setcdr (last comps) nil))
-    (setq comps (seq-uniq (mapcar (lambda (x) (substring-no-properties x)) comps)))))
+    (setq comps (seq-uniq (mapcar (lambda (x) (substring-no-properties x))
+                                  comps)))))
 
-(defvar bufferlo--frameset-save-filter ; filter out vs. frameset-persistent-filter-alist
+;; filter out vs. frameset-persistent-filter-alist
+(defvar bufferlo--frameset-save-filter
   '(;; bufferlo parameters
     bufferlo-bookmark-frame-name
     ;; Emacs parameters
@@ -2549,13 +2610,14 @@ Geometry set for FRAME or the current frame, if nil."
   ;; needed sit-for calls.
   (setq frame (or frame (selected-frame)))
   (let-alist frame-geometry
-    ;; sleeps wait for window managers like GTK/GNOME to catch up
-    (when (and .left .top .width .height) ; defensive in case geometry stored from a tty
+    ;; The sleeps (sleep-for) wait for window managers to catch up.
+    ;; Be defensive in case the geometry was stored from a tty.
+    (when (and .left .top .width .height)
       (let ((frame-resize-pixelwise t)
             (frame-inhibit-implied-resize t))
         (set-frame-position frame .left .top)
         (sleep-for bufferlo-frame-sleep-for)
-        ;; Clamp to restore frames larger than the current display size.
+        ;; Clamp size to restore frames larger than the current display size.
         (set-frame-size frame
                         (min .width (display-pixel-width))
                         (min .height (display-pixel-height))
@@ -2579,7 +2641,10 @@ representing logical container frames.
 FRAMESET is a bufferlo-filtered `frameset'."
   (let ((bookmark-record (bookmark-make-record-default t t 0))) ; (&optional no-file no-context posn)
     (bookmark-prop-set bookmark-record
-                       'bufferlo-bookmark-names (if (consp active-bookmark-names) active-bookmark-names (list active-bookmark-names)))
+                       'bufferlo-bookmark-names
+                       (if (consp active-bookmark-names)
+                           active-bookmark-names
+                         (list active-bookmark-names)))
     (bookmark-prop-set bookmark-record
                        'bufferlo-tabsets (prin1-to-string tabsets))
     (bookmark-prop-set bookmark-record
@@ -2601,21 +2666,26 @@ FRAMESET is a bufferlo-filtered `frameset'."
         ;; frameset-restore checks for fullscreen in frame parameters
         ;; and its handling is wonky and the restore filter has no
         ;; effect, so we remove it locally.
-        (default-frame-alist (assq-delete-all 'fullscreen (copy-tree default-frame-alist))))
+        (default-frame-alist (assq-delete-all 'fullscreen
+                                              (copy-tree default-frame-alist))))
     (with-temp-buffer
       (ignore-errors
-        ;; Sadly, frameset-restore returns neither a status nor a list of restored frames.
-        (frameset-restore frameset
-                          :filters
-                          (when (memq bufferlo-frameset-restore-geometry '(bufferlo nil))
-                            (let ((filtered-alist (copy-tree frameset-persistent-filter-alist)))
-                              (mapc (lambda (sym) (setf (alist-get sym filtered-alist) :never))
-                                    (seq-union bufferlo--frameset-restore-filter bufferlo-frameset-restore-filter))
-                              filtered-alist))
-                          :reuse-frames (plist-get params :reuse-frames)
-                          :force-display (plist-get params :force-display)
-                          :force-onscreen (plist-get params :force-onscreen)
-                          :cleanup-frames (plist-get params :cleanup-frames))))))
+        ;; Sadly, frameset-restore returns neither a status nor a list
+        ;; of restored frames.
+        (frameset-restore
+         frameset
+         :filters
+         (when (memq bufferlo-frameset-restore-geometry '(bufferlo nil))
+           (let ((filtered-alist
+                  (copy-tree frameset-persistent-filter-alist)))
+             (mapc (lambda (sym) (setf (alist-get sym filtered-alist) :never))
+                   (seq-union bufferlo--frameset-restore-filter
+                              bufferlo-frameset-restore-filter))
+             filtered-alist))
+         :reuse-frames (plist-get params :reuse-frames)
+         :force-display (plist-get params :force-display)
+         :force-onscreen (plist-get params :force-onscreen)
+         :cleanup-frames (plist-get params :cleanup-frames))))))
 
 (defun bufferlo--bookmark-set-handler (bookmark-record &optional no-message)
   "Handle bufferlo bookmark set.
@@ -2732,7 +2802,8 @@ message."
         (dolist (group tbm-frame-groups)
           (let ((tbm-frame (car group))
                 (tbm-names (mapcar #'car (cdr group))))
-            (push `((bufferlo--frame-geometry . ,(funcall bufferlo-frame-geometry-function tbm-frame))
+            (push `((bufferlo--frame-geometry
+                     . ,(funcall bufferlo-frame-geometry-function tbm-frame))
                     (bufferlo--tbms . ,tbm-names))
                   tabsets)))
         (when fbm-frames
@@ -2747,9 +2818,12 @@ message."
           ;; detection.
           (dolist (frame fbm-frames)
             (set-frame-parameter frame 'bufferlo--frame-to-restore t)
-            (set-frame-parameter frame 'bufferlo--frame-geometry (funcall bufferlo-frame-geometry-function frame))
+            (set-frame-parameter frame 'bufferlo--frame-geometry
+                                 (funcall bufferlo-frame-geometry-function
+                                          frame))
             (set-frame-parameter frame 'bufferlo--bookmark-frame-name
-                                 (frame-parameter frame 'bufferlo-bookmark-frame-name)))
+                                 (frame-parameter frame
+                                                  'bufferlo-bookmark-frame-name)))
           ;; frameset-save squirrels away width/height text-pixels iff
           ;; fullscreen is not nil and frame-resize-pixelwise is t.
           (let ((frame-resize-pixelwise t))
@@ -2758,17 +2832,22 @@ message."
                    fbm-frames
                    :app 'bufferlo
                    :name bookmark-name
-                   :predicate (lambda (x) (not (frame-parameter x 'parent-frame)))
+                   :predicate (lambda (x)
+                                (not (frame-parameter x 'parent-frame)))
                    :filters
-                   (let ((filtered-alist (copy-tree frameset-persistent-filter-alist)))
-                     (mapc (lambda (sym) (setf (alist-get sym filtered-alist) :never))
-                           (seq-union bufferlo--frameset-save-filter bufferlo-frameset-save-filter))
+                   (let ((filtered-alist
+                          (copy-tree frameset-persistent-filter-alist)))
+                     (mapc (lambda (sym)
+                             (setf (alist-get sym filtered-alist) :never))
+                           (seq-union bufferlo--frameset-save-filter
+                                      bufferlo-frameset-save-filter))
                      filtered-alist)))))
         (bookmark-store bookmark-name
                         (bufferlo--bookmark-set-location
-                         (bufferlo--bookmark-set-make active-bookmark-names tabsets frameset))
+                         (bufferlo--bookmark-set-make
+                          active-bookmark-names tabsets frameset))
                         no-overwrite)
-        (message "Saved bookmark set %s containing %s"
+        (message "Saved bookmark set \"%s\" containing: %s"
                  bookmark-name
                  (mapconcat #'identity active-bookmark-names " "))))))
 
@@ -2804,7 +2883,8 @@ throwing away the old one."
   "Save active constituents in selected bookmark sets."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
-         (comps (bufferlo--bookmark-completing-read "Select sets to save: " candidates)))
+         (comps (bufferlo--bookmark-completing-read "Select sets to save: "
+                                                    candidates)))
     (let* ((abms (bufferlo--active-bookmarks))
            (abm-names (mapcar #'car abms))
            (abm-names-to-save))
@@ -2812,7 +2892,8 @@ throwing away the old one."
         (setq abm-names-to-save
               (append abm-names-to-save
                       (seq-intersection
-                       (alist-get 'bufferlo-bookmark-names (assoc set-name bufferlo--active-sets))
+                       (alist-get 'bufferlo-bookmark-names
+                                  (assoc set-name bufferlo--active-sets))
                        abm-names))))
       (setq abm-names-to-save (seq-uniq abm-names-to-save))
       (bufferlo--bookmarks-save abm-names-to-save abms))))
@@ -2842,7 +2923,8 @@ This does not close its associated bookmarks or kill their
 buffers."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
-         (comps (bufferlo--bookmark-completing-read "Select sets to clear: " candidates)))
+         (comps (bufferlo--bookmark-completing-read "Select sets to clear: "
+                                                    candidates)))
     (bufferlo--set-clear comps)))
 
 (defun bufferlo-set-close-interactive ()
@@ -2850,7 +2932,8 @@ buffers."
 This closes their associated bookmarks and kills their buffers."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
-         (comps (bufferlo--bookmark-completing-read "Select sets to close/kill: " candidates)))
+         (comps (bufferlo--bookmark-completing-read "Select sets to close/kill: "
+                                                    candidates)))
     (let* ((abms (bufferlo--active-bookmarks))
            (abm-names (mapcar #'car abms))
            (abm-names-to-close))
@@ -2858,7 +2941,8 @@ This closes their associated bookmarks and kills their buffers."
         (setq abm-names-to-close
               (append abm-names-to-close
                       (seq-intersection
-                       (alist-get 'bufferlo-bookmark-names (assoc set-name bufferlo--active-sets))
+                       (alist-get 'bufferlo-bookmark-names
+                                  (assoc set-name bufferlo--active-sets))
                        abm-names))))
       (setq abm-names-to-close (seq-uniq abm-names-to-close))
       (bufferlo--close-active-bookmarks abm-names-to-close abms)
@@ -2891,7 +2975,8 @@ This closes their associated bookmarks and kills their buffers."
   "Enumerate the bookmarks in active bookmark sets."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
-         (comps (bufferlo--bookmark-completing-read "Select sets to enumerate: " candidates)))
+         (comps (bufferlo--bookmark-completing-read "Select sets to enumerate: "
+                                                    candidates)))
     (let* ((abms (bufferlo--active-bookmarks)))
       (with-current-buffer (get-buffer-create bufferlo--set-list-buffer-name)
         (let ((buffer-undo-list t))
@@ -2918,7 +3003,9 @@ This closes their associated bookmarks and kills their buffers."
                                    (truncate-string-to-width bname 20 nil nil t)
                                    (alist-get type bufferlo--bookmark-type-names)
                                    (truncate-string-to-width fname 25 nil nil t)
-                                   (if tab-number (format "tab:%d" tab-number) ""))))
+                                   (if tab-number
+                                       (format "tab:%d" tab-number)
+                                     ""))))
                 (put-text-property 0 (length text) 'bookmark-name bname text)
                 (insert text "\n"))))
           (insert "\n"))
@@ -2934,7 +3021,8 @@ This closes their associated bookmarks and kills their buffers."
    #'car
    (seq-filter
     (lambda (bm)
-      (memq (alist-get 'handler (cdr bm)) (or handlers bufferlo--bookmark-handlers)))
+      (memq (alist-get 'handler (cdr bm))
+            (or handlers bufferlo--bookmark-handlers)))
     bookmark-alist)))
 
 (defun bufferlo--current-tab ()
@@ -2949,7 +3037,9 @@ NAME is the bookmark's name. If NO-OVERWRITE is non-nil, record
 the new bookmark without throwing away the old one. NO-MESSAGE
 inhibits the save status message. If MSG is non-nil, it is added
 to the save message."
-  (bookmark-store name (bufferlo--bookmark-set-location (bufferlo--bookmark-tab-make)) no-overwrite)
+  (bookmark-store name (bufferlo--bookmark-set-location
+                        (bufferlo--bookmark-tab-make))
+                  no-overwrite)
   (setf (alist-get 'bufferlo-bookmark-tab-name
                    (cdr (bufferlo--current-tab)))
         name)
@@ -2981,7 +3071,8 @@ is not recommended."
   (bufferlo--warn)
   (catch :abort
     (let* ((abm (assoc name (bufferlo--active-bookmarks)))
-           (tbm (alist-get 'bufferlo-bookmark-tab-name (tab-bar--current-tab-find)))
+           (tbm (alist-get 'bufferlo-bookmark-tab-name
+                           (tab-bar--current-tab-find)))
            (msg)
            (msg-append (lambda (s) (setq msg (concat msg "; " s)))))
 
@@ -3079,7 +3170,8 @@ This reuses the current tab even if
 (defun bufferlo--clear-frame-bookmarks-by-name (bookmark-name)
   "Clear BOOKMARK-NAME frame bookmarks across all frames."
   (dolist (frame (frame-list))
-    (when (equal bookmark-name (frame-parameter frame 'bufferlo-bookmark-frame-name))
+    (when (equal bookmark-name
+                 (frame-parameter frame 'bufferlo-bookmark-frame-name))
       (set-frame-parameter frame 'bufferlo-bookmark-frame-name nil))))
 
 (defun bufferlo--bookmark-frame-save (name &optional no-overwrite no-message msg)
@@ -3088,7 +3180,9 @@ NAME is the bookmark's name. If NO-OVERWRITE is non-nil, record
 the new bookmark without throwing away the old one. If NO-MESSAGE
 is non-nil, inhibit the save status message. If MSG is non-nil,
 it is added to the save message."
-  (bookmark-store name (bufferlo--bookmark-set-location (bufferlo--bookmark-frame-make)) no-overwrite)
+  (bookmark-store name (bufferlo--bookmark-set-location
+                        (bufferlo--bookmark-frame-make))
+                  no-overwrite)
   (set-frame-parameter nil 'bufferlo-bookmark-frame-name name)
   (unless no-message
     (message "Saved bufferlo frame bookmark: %s%s" name (if msg msg ""))))
@@ -3121,7 +3215,7 @@ but is not recommended."
            (msg)
            (msg-append (lambda (s) (setq msg (concat msg "; " s)))))
 
-      ;; Only check policies when the bm is not already associated with this frame
+      ;; Only check policies when bm is not already associated with this frame
       (unless (and fbm (equal fbm (car abm)))
 
         ;; Bookmark already loaded in another frame?
@@ -3191,7 +3285,8 @@ associated bookmark exists."
   (bufferlo--warn)
   (if-let* ((bm (frame-parameter nil 'bufferlo-bookmark-frame-name)))
       (let ((bufferlo-bookmark-frame-load-make-frame nil) ; reload reuses the current frame
-            (bufferlo-bookmark-frame-load-policy 'replace-frame-retain-current-bookmark)
+            (bufferlo-bookmark-frame-load-policy
+             'replace-frame-retain-current-bookmark)
             (bufferlo-bookmark-frame-duplicate-policy 'allow)) ; not technically a duplicate
         (bufferlo-bookmark-frame-load bm))
     (call-interactively #'bufferlo-bookmark-frame-load)))
@@ -3218,13 +3313,16 @@ filtered by TYPE, where type is:
       (when-let* ((fbm (frame-parameter frame 'bufferlo-bookmark-frame-name)))
         (when (or (null type) (eq type 'fbm))
           (push (list fbm `((type . fbm)
-                            (frame . ,frame))) abms)))
+                            (frame . ,frame)))
+                abms)))
       (dolist (tab (funcall tab-bar-tabs-function frame))
         (when-let* ((tbm (alist-get 'bufferlo-bookmark-tab-name tab)))
           (when (or (null type) (eq type 'tbm))
             (push (list tbm `((type . tbm)
                               (frame . ,frame)
-                              (tab-number . ,(1+ (tab-bar--tab-index tab nil frame))))) abms)))))
+                              (tab-number . ,(1+ (tab-bar--tab-index
+                                                  tab nil frame)))))
+                  abms)))))
     abms))
 
 (defun bufferlo-bookmarks-save-all-p (_bookmark-name)
@@ -3250,7 +3348,7 @@ This is intended to be used in
 
 (defun bufferlo--list-duplicates (lst)
   "Return unique duplicate elements from LST.
-Equality test is 'equal,"
+Equality test is \\='equal."
   (let ((ht (make-hash-table :test 'equal :size (length lst))))
     (mapc (lambda (x) (puthash x (if (gethash x ht) 'dupe t) ht)) lst)
     (seq-uniq
@@ -3262,7 +3360,8 @@ Equality test is 'equal,"
 Specify NO-MESSAGE to inhibit the bookmark save status message."
   (let ((bookmarks-saved nil)
         (start-time (current-time)))
-    (let ((bookmark-save-flag nil)) ; inhibit built-in bookmark file saving until we're done
+    ; Inhibit built-in bookmark file saving until we're done
+    (let ((bookmark-save-flag nil))
       (dolist (abm-name active-bookmark-names)
         (when-let* ((abm (assoc abm-name active-bookmarks))
                     (abm-type (alist-get 'type (cadr abm)))
@@ -3280,14 +3379,16 @@ Specify NO-MESSAGE to inhibit the bookmark save status message."
     (cond
      (bookmarks-saved
       (let ((inhibit-message (or no-message
-                                 (not (memq bufferlo-bookmarks-auto-save-messages (list 'saved t))))))
+                                 (not (memq bufferlo-bookmarks-auto-save-messages
+                                            (list 'saved t))))))
         (bookmark-save)
         (message "Saved bufferlo bookmarks: %s, in %.2f second(s)"
                  (mapconcat 'identity bookmarks-saved " ")
                  (float-time (time-subtract (current-time) start-time)))))
      (t
       (when (and (not no-message)
-                 (memq bufferlo-bookmarks-auto-save-messages (list 'notsaved t)))
+                 (memq bufferlo-bookmarks-auto-save-messages
+                       (list 'notsaved t)))
         (message "No bufferlo bookmarks saved."))))))
 
 (defun bufferlo-bookmarks-save (&optional all)
@@ -3396,10 +3497,12 @@ This honors `bufferlo-bookmarks-save-at-emacs-exit' by predicate or
 
 (defun bufferlo--bookmarks-load-startup ()
   "Load bookmarks at startup."
-  (let ((bufferlo-bookmarks-load-tabs-make-frame bufferlo-bookmarks-load-at-emacs-startup-tabs-make-frame))
-    (run-with-idle-timer 0 nil
-                         (lambda ()
-                           (bufferlo-bookmarks-load (eq bufferlo-bookmarks-load-at-emacs-startup 'all))))))
+  (let ((bufferlo-bookmarks-load-tabs-make-frame
+         bufferlo-bookmarks-load-at-emacs-startup-tabs-make-frame))
+    (run-with-idle-timer 0 nil (lambda ()
+                                 (bufferlo-bookmarks-load
+                                  (eq bufferlo-bookmarks-load-at-emacs-startup
+                                      'all))))))
 
 (defun bufferlo-bookmarks-load (&optional all)
   "Load stored bufferlo bookmarks.
@@ -3434,9 +3537,11 @@ current or new frame according to
          (current-prefix-arg nil))
 
     ;; load bookmark sets
-    (dolist (bookmark-name (bufferlo--bookmark-get-names #'bufferlo--bookmark-set-handler))
+    (dolist (bookmark-name (bufferlo--bookmark-get-names
+                            #'bufferlo--bookmark-set-handler))
       (unless (assoc bookmark-name bufferlo--active-sets)
-        (when (run-hook-with-args-until-success 'bufferlo-bookmarks-load-predicate-functions bookmark-name)
+        (when (run-hook-with-args-until-success
+               'bufferlo-bookmarks-load-predicate-functions bookmark-name)
           (if (bufferlo--bookmark-jump bookmark-name)
               (push bookmark-name bookmarks-loaded)
             (push bookmark-name bookmarks-failed)))))
@@ -3447,10 +3552,13 @@ current or new frame according to
     (let ((bufferlo-bookmark-tab-replace-policy 'replace) ; we handle making tabs in this loop
           (tab-bar-new-tab-choice t)
           (new-tab-frame nil))
-      (dolist (bookmark-name (bufferlo--bookmark-get-names #'bufferlo--bookmark-tab-handler))
+      (dolist (bookmark-name (bufferlo--bookmark-get-names
+                              #'bufferlo--bookmark-tab-handler))
         (unless (assoc bookmark-name (bufferlo--active-bookmarks))
-          (when (run-hook-with-args-until-success 'bufferlo-bookmarks-load-predicate-functions bookmark-name)
-            (if (and bufferlo-bookmarks-load-tabs-make-frame (not new-tab-frame))
+          (when (run-hook-with-args-until-success
+                 'bufferlo-bookmarks-load-predicate-functions bookmark-name)
+            (if (and bufferlo-bookmarks-load-tabs-make-frame
+                     (not new-tab-frame))
                 (select-frame (setq new-tab-frame (make-frame)))
               (tab-bar-new-tab-to))
             (if (bufferlo--bookmark-jump bookmark-name)
@@ -3458,9 +3566,11 @@ current or new frame according to
               (push bookmark-name bookmarks-failed))))))
 
     ;; load frame bookmarks
-    (dolist (bookmark-name (bufferlo--bookmark-get-names #'bufferlo--bookmark-frame-handler))
+    (dolist (bookmark-name (bufferlo--bookmark-get-names
+                            #'bufferlo--bookmark-frame-handler))
       (unless (assoc bookmark-name (bufferlo--active-bookmarks))
-        (when (run-hook-with-args-until-success 'bufferlo-bookmarks-load-predicate-functions bookmark-name)
+        (when (run-hook-with-args-until-success
+               'bufferlo-bookmarks-load-predicate-functions bookmark-name)
           (if (bufferlo--bookmark-jump bookmark-name)
               (push bookmark-name bookmarks-loaded)
             (push bookmark-name bookmarks-failed)))))
@@ -3482,7 +3592,8 @@ current or new frame according to
   (interactive)
   (let* ((abms (bufferlo--active-bookmarks))
          (abm-names (mapcar #'car abms))
-         (comps (bufferlo--bookmark-completing-read "Close bookmark(s) without saving: " abm-names)))
+         (comps (bufferlo--bookmark-completing-read
+                 "Close bookmark(s) without saving: " abm-names)))
     (bufferlo--close-active-bookmarks comps abms)))
 
 (defun bufferlo-bookmarks-save-interactive ()
@@ -3490,7 +3601,8 @@ current or new frame according to
   (interactive)
   (let* ((abms (bufferlo--active-bookmarks))
          (abm-names (mapcar #'car abms))
-         (comps (bufferlo--bookmark-completing-read "Save bookmark(s): " abm-names)))
+         (comps (bufferlo--bookmark-completing-read
+                 "Save bookmark(s): " abm-names)))
     (bufferlo--bookmarks-save comps abms)))
 
 (defun bufferlo-bookmarks-load-interactive ()
@@ -3502,11 +3614,18 @@ bookmarks, double for bookmarks, triple for bookmark sets."
   (let* ((bookmark-names
           (apply 'bufferlo--bookmark-get-names
                  (cond
-                  ((and (consp current-prefix-arg) (eq (prefix-numeric-value current-prefix-arg) 4)) (list #'bufferlo--bookmark-frame-handler))
-                  ((and (consp current-prefix-arg) (eq (prefix-numeric-value current-prefix-arg) 16)) (list #'bufferlo--bookmark-tab-handler))
-                  ((and (consp current-prefix-arg) (eq (prefix-numeric-value current-prefix-arg) 64)) (list #'bufferlo--bookmark-set-handler))
+                  ((and (consp current-prefix-arg)
+                        (eq (prefix-numeric-value current-prefix-arg) 4))
+                   (list #'bufferlo--bookmark-frame-handler))
+                  ((and (consp current-prefix-arg)
+                        (eq (prefix-numeric-value current-prefix-arg) 16))
+                   (list #'bufferlo--bookmark-tab-handler))
+                  ((and (consp current-prefix-arg)
+                        (eq (prefix-numeric-value current-prefix-arg) 64))
+                   (list #'bufferlo--bookmark-set-handler))
                   (t bufferlo--bookmark-handlers))))
-         (comps (bufferlo--bookmark-completing-read "Load bookmark(s): " bookmark-names)))
+         (comps (bufferlo--bookmark-completing-read "Load bookmark(s): "
+                                                    bookmark-names)))
     (dolist (bookmark-name comps)
       (bufferlo--bookmark-jump bookmark-name))))
 
@@ -3524,9 +3643,16 @@ FORCE will clear the bookmark even if it is currently unique.
 Specify a prefix argument to imply FORCE."
   (interactive)
   (let* ((fbm (frame-parameter nil 'bufferlo-bookmark-frame-name))
-         (tbm (alist-get 'bufferlo-bookmark-tab-name (tab-bar--current-tab-find)))
-         (duplicate-fbm (> (length (seq-filter (lambda (x) (equal fbm (car x))) (bufferlo--active-bookmarks nil 'fbm))) 1))
-         (duplicate-tbm (> (length (seq-filter (lambda (x) (equal tbm (car x))) (bufferlo--active-bookmarks nil 'tbm))) 1)))
+         (tbm (alist-get 'bufferlo-bookmark-tab-name
+                         (tab-bar--current-tab-find)))
+         (duplicate-fbm (> (length (seq-filter
+                                    (lambda (x) (equal fbm (car x)))
+                                    (bufferlo--active-bookmarks nil 'fbm)))
+                           1))
+         (duplicate-tbm (> (length (seq-filter
+                                    (lambda (x) (equal tbm (car x)))
+                                    (bufferlo--active-bookmarks nil 'tbm)))
+                           1)))
     (when (or force (consp current-prefix-arg) duplicate-fbm)
       (set-frame-parameter nil 'bufferlo-bookmark-frame-name nil))
     (when (or force (consp current-prefix-arg) duplicate-tbm)
@@ -3614,12 +3740,13 @@ A prefix argument inhibits the prompt and bypasses saving."
       (unless (consp current-prefix-arg)
         (pcase (let ((read-answer-short t))
                  (with-local-quit
-                   (read-answer "Save bookmarks before closing them: All, Predicate, No save "
-                                '(("all" ?a "Save all active bookmarks")
-                                  ("pred" ?p "Save predicate-filtered bookmarks, if set")
-                                  ("nosave" ?n "Don't save")
-                                  ("help" ?h "Help")
-                                  ("quit" ?q "Quit")))))
+                   (read-answer
+                    "Save bookmarks before closing them: All, Predicate, No save "
+                    '(("all" ?a "Save all active bookmarks")
+                      ("pred" ?p "Save predicate-filtered bookmarks, if set")
+                      ("nosave" ?n "Don't save")
+                      ("help" ?h "Help")
+                      ("quit" ?q "Quit")))))
           ("all"
            (bufferlo-bookmarks-save 'all))
           ("pred"
@@ -3653,7 +3780,8 @@ raised."
   (interactive)
   (let* ((abms (bufferlo--active-bookmarks))
          (abm-names (mapcar #'car abms))
-         (comps (bufferlo--bookmark-completing-read "Select a bookmark to raise: " abm-names)))
+         (comps (bufferlo--bookmark-completing-read
+                 "Select a bookmark to raise: " abm-names)))
     (if (not (= (length comps) 1))
         (message "Please select a single bookmark to raise")
       (bufferlo--bookmark-raise-by-name (car comps) abms))))
@@ -3691,7 +3819,8 @@ load a new bookmark."
   (bufferlo--warn)
   (if-let* ((bm (frame-parameter nil 'bufferlo-bookmark-frame-name)))
       (let ((bufferlo-bookmark-frame-load-make-frame nil) ; reload reuses the current frame
-            (bufferlo-bookmark-frame-load-policy 'replace-frame-retain-current-bookmark)
+            (bufferlo-bookmark-frame-load-policy
+             'replace-frame-retain-current-bookmark)
             (bufferlo-bookmark-frame-duplicate-policy 'allow)) ; not technically a duplicate
         (bufferlo-bookmark-frame-load bm))
     (if-let* ((bm (alist-get 'bufferlo-bookmark-tab-name
@@ -3729,7 +3858,9 @@ OLDFN OLD-NAME NEW-NAME"
   (if (called-interactively-p 'interactive)
       (setq old-name (bookmark-completing-read "Old bookmark name")))
   (if-let* ((abm (assoc old-name (bufferlo--active-bookmarks))))
-      (user-error "%s is an active bufferlo bookmark--close its frame/tab, or clear it before renaming" old-name)
+      (user-error
+       "%s is an active bufferlo bookmark--close its frame/tab, or clear it before renaming"
+       old-name)
     (if (called-interactively-p 'interactive)
         (funcall-interactively oldfn old-name new-name)
       (funcall oldfn old-name new-name))))
@@ -3743,7 +3874,9 @@ OLDFN BOOKMARK-NAME BATCH"
       (setq bookmark-name (bookmark-completing-read "Delete bookmark"
                                                     bookmark-current-bookmark)))
   (if-let* ((abm (assoc bookmark-name (bufferlo--active-bookmarks))))
-      (user-error "%s is an active bufferlo bookmark--close its frame/tab, or clear it before deleting" bookmark-name)
+      (user-error
+       "%s is an active bufferlo bookmark--close its frame/tab, or clear it before deleting"
+       bookmark-name)
     (if (called-interactively-p 'interactive)
         (funcall-interactively oldfn bookmark-name batch)
       (funcall oldfn bookmark-name batch))))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -3249,16 +3249,14 @@ This is intended to be used in
         (push abm abm-dupes)))
     abm-dupes))
 
-(defun bufferlo--string-duplicates (strings)
-  "Return a list of duplicate strings in STRINGS."
-  (let ((dupes))
-    (cl-mapl (lambda (lst)
-               (when (string= (nth 0 lst) (nth 1 lst))
-                 (push (nth 0 lst) dupes)))
-             (seq-sort
-              (lambda (a b) (string< a b))
-              strings))
-    (seq-uniq dupes)))
+(defun bufferlo--list-duplicates (lst)
+  "Return unique duplicate elements from LST.
+Equality test is 'equal,"
+  (let ((ht (make-hash-table :test 'equal :size (length lst))))
+    (mapc (lambda (x) (puthash x (if (gethash x ht) 'dupe t) ht)) lst)
+    (seq-uniq
+     (delq nil
+           (mapcar (lambda (x) (when (eq (gethash x ht) 'dupe) x)) lst)))))
 
 (defun bufferlo--bookmarks-save (active-bookmark-names active-bookmarks &optional no-message)
   "Save the bookmarks in ACTIVE-BOOKMARK-NAMES indexed by ACTIVE-BOOKMARKS.
@@ -3340,7 +3338,7 @@ Duplicate bookmarks are handled according to
                                            abm-name)
                                       abm-name)))
                                 abms)))
-           (dupes-to-save (bufferlo--string-duplicates abm-names-to-save))
+           (dupes-to-save (bufferlo--list-duplicates abm-names-to-save))
            (duplicate-policy bufferlo-bookmarks-save-duplicates-policy))
       (when (> (length dupes-to-save) 0)
         (when (eq duplicate-policy 'prompt)

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2310,7 +2310,8 @@ this bookmark is embedded in a frame bookmark."
             ('replace)
             ('new
              (unless (consp current-prefix-arg) ; user new tab suppression
-               (tab-bar-new-tab-to)))))
+               (let ((tab-bar-new-tab-choice t))
+                 (tab-bar-new-tab-to))))))
 
         ;; Handle an independent tab bookmark inside a frame bookmark
         (when (and bookmark-name

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1035,10 +1035,10 @@ string, FACE is the face for STR."
 
 ;; NOTE: Undocumented in `make-frame' that the current buffer cannot be
 ;; conventionally hidden (space as first character). `with-temp-buffer'
-;; doesn't work either in this context.
+;; doesn't work either in this context (for the same reason).
 (defmacro bufferlo--with-temp-buffer (&rest body)
-  "Execute BODY with \"*bufferlo tenp buffer*\" current buffer."
-  (let ((buff-name "*bufferlo temp buffer*"))
+  "Execute BODY with \"*bufferlo temp buffer*\" current buffer."
+  (let ((buff-name (generate-new-buffer-name "*bufferlo temp buffer*")))
     (with-current-buffer (get-buffer-create buff-name t)
       (unwind-protect
           `(progn ,@body)

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2131,20 +2131,22 @@ local buffer list to use.  If it is nil, the current frame is used."
                         buffers)))
     (seq-union buffers-excl buffers-incl)))
 
-(defun bufferlo--bookmark-get-for-buffers-in-tab (frame)
+(defun bufferlo--bookmark-get-for-buffers-in-tab (buffers)
   "Get bookmarks for all buffers of the selected tab in FRAME."
-  (with-selected-frame (or frame (selected-frame))
-    (seq-filter #'identity
-                (mapcar #'bufferlo--bookmark-get-for-buffer
-                        (bufferlo--bookmark-filter-buffers frame)))))
+  (seq-filter #'identity
+              (mapcar #'bufferlo--bookmark-get-for-buffer
+                      buffers)))
 
 (defun bufferlo--bookmark-tab-make (&optional frame)
   "Get the bufferlo tab bookmark for the current tab in FRAME.
 FRAME specifies the frame; the default value of nil selects the current frame."
-  `((buffer-bookmarks . ,(bufferlo--bookmark-get-for-buffers-in-tab frame))
-    (buffer-list . ,(mapcar #'buffer-name (bufferlo-buffer-list frame nil t)))
-    (window . ,(window-state-get (frame-root-window frame) 'writable))
-    (handler . ,#'bufferlo--bookmark-tab-handler)))
+  (let ((filtered-buffers
+         (with-selected-frame (or frame (selected-frame))
+           (bufferlo--bookmark-filter-buffers frame))))
+    `((buffer-bookmarks . ,(bufferlo--bookmark-get-for-buffers-in-tab filtered-buffers))
+      (buffer-list . ,(mapcar #'buffer-name filtered-buffers))
+      (window . ,(window-state-get (frame-root-window frame) 'writable))
+      (handler . ,#'bufferlo--bookmark-tab-handler))))
 
 (defun bufferlo--ws-replace-buffer-names (ws replace-alist)
   "Replace buffer names according to REPLACE-ALIST in the window state WS."

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -276,6 +276,8 @@ its bookmark.
 \\='raise will raise the frame with the existing bookmark."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
+                (const :tag "Clear (silently)" clear)
+                (const :tag "Clear (with message)" clear-warn)
                 (const :tag "Raise" raise)))
 
 (defcustom bufferlo-bookmark-frame-clone-policy 'prompt

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2276,7 +2276,7 @@ this bookmark is embedded in a frame bookmark."
                                               record)
                                      (run-hooks 'bookmark-after-jump-hook))
                             (error
-                             (message "Bufferlo tab: Could not restore %s (error %s)"
+                             (message "Bufferlo bookmark: Could not restore %s (error %s)"
                                       orig-name err)))
                           (unless (eq (current-buffer) dummy)
                             (unless (string-equal orig-name (buffer-name))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -134,8 +134,8 @@ This policy applies to all bufferlo functions that entail killing buffers,
 e.g., `bufferlo-kill-buffers', `bufferlo-kill-orphan-buffers',
 `bufferlo-tab-close-kill-buffers', `bufferlo-delete-frame-kill-buffers'.
 
-This policy is useful when `shell-mode' or `eshell-mode' buffers
-are active in a bufferlo-controlled frame or tab.
+This policy is useful if `shell-mode' or `eshell-mode' buffers are
+active in a bufferlo-controlled frame or tab.
 
 nil means default Emacs behavior which may prompt.  This may have
 side effects.
@@ -159,7 +159,7 @@ without remorse including those with running processes such as
 
 (defcustom bufferlo-bookmark-inhibit-bookmark-point nil
   "If non-nil, inhibit point in bookmarks.
-This is useful when `save-place-mode' mode is enabled."
+This is useful if `save-place-mode' mode is enabled."
   :type 'boolean)
 
 (defcustom bufferlo-bookmark-buffers-exclude-filters nil
@@ -337,7 +337,7 @@ Note: \\='raise is considered \\='clear during `bookmark-set' loading."
                 (const :tag "Raise" raise)))
 
 (defcustom bufferlo-bookmark-tab-in-bookmarked-frame-policy 'prompt
-  "Control when a tab bookmark is loaded into an already-bookmarked frame.
+  "Control how a tab bookmark is loaded into an already-bookmarked frame.
 
 This also warns about setting a new frame bookmark on a frame
 that has tab bookmarks, and vice versa setting a tab bookmark on
@@ -351,7 +351,7 @@ bookmark.
 
 \\='allow will retain the tab bookmark to enable it to be saved
 or updated.  Note that the frame bookmark always supersedes the tab
-bookmark when the frame bookmark is saved."
+bookmark if the frame bookmark is saved."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
                 (const :tag "Clear (silently)" clear)
@@ -371,7 +371,7 @@ bookmarks.
 bookmark content for the same bookmark names.  A warning message
 indicates the names of duplicate bookmarks.
 
-Note: when using bufferlo's auto-save feature and to avoid
+Note: When using bufferlo's auto-save feature, and to avoid
 repeated prompts and warnings, it is best to choose policies in
 advance that prevent duplicate frame and tab bookmarks."
   :type '(radio (const :tag "Prompt" prompt)
@@ -1081,7 +1081,7 @@ buffers, see `bufferlo-hidden-buffers'."
 
 (defun bufferlo--clear-buffer-lists (&optional frame)
   "This is a workaround advice function to fix tab-bar's tab switching behavior.
-On `tab-bar-select-tab', when `wc-bl' or `wc-bbl' is nil, the function does not
+On `tab-bar-select-tab', if `wc-bl' or `wc-bbl' is nil, the function does not
 set the corresponding `buffer-list' / `buried-buffer-list' frame parameters.
 As a result the previous tab's values remain active.
 
@@ -1627,10 +1627,10 @@ The optional arguments KILLALL and INTERNAL-TOO are passed to
 
 (defun bufferlo-isolate-project (&optional file-buffers-only)
   "Isolate a project in the frame or tab.
-Remove all buffers that do not belong to the current project from
-the local buffer list.  When FILE-BUFFERS-ONLY is non-nil or the
-prefix argument is given, remove only buffers that visit a file.
-Buffers matching `bufferlo-include-buffer-filters' are not removed."
+Remove all buffers that do not belong to the current project from the
+local buffer list.  If FILE-BUFFERS-ONLY is non-nil or the prefix
+argument is given, remove only buffers that visit a file.  Buffers
+matching `bufferlo-include-buffer-filters' are not removed."
   (interactive "P")
   (bufferlo--warn)
   (if-let* ((curr-project (project-current))
@@ -1912,7 +1912,7 @@ for (almost) all functions.  Customize `bufferlo-anywhere-filter' and
 `bufferlo-anywhere-filter-type' to adapt the behavior.
 This minor mode requires `bufferlo-mode' to be enabled.
 You can use `bufferlo-anywhere-disable' to disable the local buffer list for
-the next command, when the mode is enabled."
+the next command, if the mode is enabled."
   :global t
   :require 'bufferlo
   :init-value nil
@@ -2167,7 +2167,7 @@ This functions throws :abort when the user quits."
 
 (defun bufferlo--bookmark-tab-get-replace-policy ()
   "Get the replace policy for tab bookmarks.
-Ask the user when `bufferlo-bookmark-tab-replace-policy' is set to \\='prompt.
+Prompt if `bufferlo-bookmark-tab-replace-policy' is set to \\='prompt.
 This functions throws :abort when the user quits."
   (if (not (eq bufferlo-bookmark-tab-replace-policy 'prompt))
       bufferlo-bookmark-tab-replace-policy
@@ -2184,7 +2184,7 @@ This functions throws :abort when the user quits."
 
 (defun bufferlo--bookmark-tab-get-clear-policy (mode)
   "Get the clear policy for tab bookmarks.
-Ask the user when `bufferlo-bookmark-tab-in-bookmarked-frame-policy' is
+Prompt if `bufferlo-bookmark-tab-in-bookmarked-frame-policy' is
 set to \\='prompt.  This functions throws :abort when the user quits.
 MODE is either \\='load, \\='save, or \\='save-frame, depending on the
 invoking action.  This functions throws :abort when the user quits."
@@ -2336,7 +2336,7 @@ FRAME specifies the frame; the default value of nil selects the current frame."
 
 (defun bufferlo--bookmark-frame-get-load-policy ()
   "Get the load policy for frame bookmarks.
-Ask the user when `bufferlo-bookmark-frame-load-policy' is set to \\='prompt.
+Prompt if `bufferlo-bookmark-frame-load-policy' is set to \\='prompt.
 This functions throws :abort when the user quits."
   (if (not (eq bufferlo-bookmark-frame-load-policy 'prompt))
       bufferlo-bookmark-frame-load-policy

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -75,7 +75,7 @@ Set to \\='ibuffer to show `ibuffer' only."
 (defcustom bufferlo-prefer-local-buffers t
   "Use the frame `buffer-predicate' to prefer local buffers.
 Without this option, buffers from across all frames are
-presented. This means that a local buffer will be preferred to be
+presented.  This means that a local buffer will be preferred to be
 displayed when the current buffer disappears (buried or killed).
 
 This also influences `next-buffer' and `previous-buffer'.
@@ -137,7 +137,7 @@ e.g., `bufferlo-kill-buffers', `bufferlo-kill-orphan-buffers',
 This policy is useful when `shell-mode' or `eshell-mode' buffers
 are active in a bufferlo-controlled frame or tab.
 
-nil means default Emacs behavior which may prompt. This may have
+nil means default Emacs behavior which may prompt.  This may have
 side effects.
 
 \\='retain-modified means bufferlo will leave modified buffers as
@@ -285,7 +285,7 @@ its bookmark.
 
 \\='raise will raise the frame with the existing bookmark.
 
-Note: \\='raise is considered \\='clear during bookmark-set loading."
+Note: \\='raise is considered \\='clear during `bookmark-set' loading."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
                 (const :tag "Clear (silently)" clear)
@@ -329,7 +329,7 @@ bookmark.
 \\='raise raises the first found existing tab bookmark and its
 frame.
 
-Note: \\='raise is considered \\='clear during bookmark-set loading."
+Note: \\='raise is considered \\='clear during `bookmark-set' loading."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
                 (const :tag "Clear (silently)" clear)
@@ -350,7 +350,7 @@ reified frame bookmark behavior.
 bookmark.
 
 \\='allow will retain the tab bookmark to enable it to be saved
-or updated. Note that the frame bookmark always supersedes the tab
+or updated.  Note that the frame bookmark always supersedes the tab
 bookmark when the frame bookmark is saved."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Allow" allow)
@@ -364,11 +364,11 @@ bookmark when the frame bookmark is saved."
 
 \\='allow will save potentially differing content for the same
 bookmark name multiple times with the last-one-saved taking
-precedence. A warning message indicates the names of duplicate
+precedence.  A warning message indicates the names of duplicate
 bookmarks.
 
 \\='disallow prevents the potentially confusing of overwriting
-bookmark content for the same bookmark names. A warning message
+bookmark content for the same bookmark names.  A warning message
 indicates the names of duplicate bookmarks.
 
 Note: when using bufferlo's auto-save feature and to avoid
@@ -395,8 +395,8 @@ advance that prevent duplicate frame and tab bookmarks."
   "Functions to filter active bufferlo bookmarks to save.
 These are applied when
 `bufferlo-bookmarks-auto-save-idle-interval' is > 0, or manually
-via `bufferlo-bookmarks-save'. Functions are passed the bufferlo
-bookmark name and invoked until the first positive result. Set to
+via `bufferlo-bookmarks-save'.  Functions are passed the bufferlo
+bookmark name and invoked until the first positive result.  Set to
 `#'bufferlo-bookmarks-save-all-p' to save all bookmarks or
 provide your own predicates (note: be sure to remove
 `#'bufferlo-bookmarks-save-all-p' from the list)."
@@ -407,7 +407,7 @@ provide your own predicates (note: be sure to remove
 These are applied in `bufferlo-bookmarks-load' which might also
 be invoked at Emacs startup time using `window-setup-hook'.
 Functions are passed the bufferlo bookmark name and invoked until
-the first positive result. Set to
+the first positive result.  Set to
 `#'bufferlo-bookmarks-load-all-p' to load all bookmarks or
 provide your own predicates."
   :type 'hook)
@@ -544,7 +544,7 @@ This is controlled by `bufferlo-bookmarks-auto-save-idle-interval'.")
 
 (defcustom bufferlo-bookmarks-auto-save-idle-interval 0
   "Save bufferlo bookmarks when Emacs has been idle this many seconds.
-Set to 0 to disable the timer. Units are whole integer seconds."
+Set to 0 to disable the timer.  Units are whole integer seconds."
   :type 'natnum
   :set (lambda (sym val)
          (set-default sym val)
@@ -642,7 +642,7 @@ It defaults to `bufferlo-frameset-restore-parameters-default'."
 It defaults to `bufferlo-frame-geometry-default'.
 
 The function takes one parameter, FRAME, for which geometry is to
-be ascertained. See `bufferlo-frame-geometry-default' for
+be ascertained.  See `bufferlo-frame-geometry-default' for
 the returned alist form.
 
 Replace this function with your own if the default produces
@@ -662,7 +662,7 @@ suboptimal results for your platform."
 (defcustom bufferlo-frame-sleep-for 0
   "Window manager catch-up delay for changing frame parameters.
 Delay is specified in seconds using `sleep-for', which see.
-GTK/GNOME seems to need 0.3 seconds. YMMV.
+GTK/GNOME seems to need 0.3 seconds.  YMMV.
 No delay seems needed on macOS."
   :type 'natnum)
 
@@ -1298,8 +1298,8 @@ the advised functions."
 
 (defun bufferlo--clone-undelete-frame-advice (oldfn &rest args)
   "Activate the advice for `clone-frame' and `undelete-frame'.
-OLDFN is the original function.  ARGS is for compatibility with
-the advised functions. Honors `bufferlo-bookmark-frame-duplicate-policy'."
+OLDFN is the original function.  ARGS is for compatibility with the
+advised functions.  Honors `bufferlo-bookmark-frame-duplicate-policy'."
   (let ((bufferlo--desktop-advice-active t)
         (bufferlo--desktop-advice-active-force t))
     (apply oldfn args))
@@ -2723,8 +2723,8 @@ the message after successfully restoring the bookmark."
              bookmark-name))
 
     ;; Restore tabsets (tabsets can be nil despite readablep)
-    (when-let ((tabsets (car (read-from-string tabsets-str)))
-               (first-tab-frame t))
+    (when-let* ((tabsets (car (read-from-string tabsets-str)))
+                (first-tab-frame t))
       (bufferlo--with-temp-buffer
        (dolist (tab-group tabsets)
          (when (or (not first-tab-frame)
@@ -2758,7 +2758,7 @@ the message after successfully restoring the bookmark."
       (select-frame-set-input-focus (selected-frame)))
 
     ;; Restore framesets (framesets can be nil despite readablep)
-    (when-let ((frameset (car (read-from-string frameset-str))))
+    (when-let* ((frameset (car (read-from-string frameset-str))))
       (unless (frameset-valid-p frameset)
         (error "Bufferlo bookmark set %s: invalid frameset"
                bookmark-name))
@@ -2802,12 +2802,12 @@ Frame bookmarks are stored with their geometry for optional
 restoration.
 
 Tab bookmarks are stored in groups associated with their current
-frame. New frames will be created to hold tab bookmarks in the
-same grouping. Order may not be preserved. Tab frame geometry is
+frame.  New frames will be created to hold tab bookmarks in the
+same grouping.  Order may not be preserved.  Tab frame geometry is
 stored for optional restoration.
 
 If NO-OVERWRITE is non-nil, record the new bookmark without
-throwing away the old one. NO-MESSAGE inhibits the save status
+throwing away the old one.  NO-MESSAGE inhibits the save status
 message."
   (let* ((abms (seq-filter
                 (lambda (x) (member (car x) active-bookmark-names))
@@ -2912,7 +2912,7 @@ throwing away the old one."
      bufferlo--active-sets)))
 
 (defun bufferlo--set-get-constituents (bsets abms)
-  "Get the constituents of the given bookmark sets from the list of bookmarks.
+  "Get the constituents of the given `bookmark-sets' from the list of bookmarks.
 BSETS is a list of the requested sets and ABMS is a list of all bookmarks to
 consider (usually all active bookmarks)."
   (let* ((abm-names (mapcar #'car abms))
@@ -2926,7 +2926,7 @@ consider (usually all active bookmarks)."
     (seq-uniq abm-names)))
 
 (defun bufferlo-set-save-current-interactive ()
-  "Save active constituents in selected bookmark sets."
+  "Save active constituents in selected `bookmark-sets'."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
          (comps (bufferlo--bookmark-completing-read "Select sets to save: "
@@ -2942,7 +2942,7 @@ consider (usually all active bookmarks)."
     (call-interactively 'bufferlo-bookmarks-load-interactive)))
 
 (defun bufferlo--set-clear-all ()
-  "Clear all active bookmark sets.
+  "Clear all active `bookmark-sets'.
 This does not close active frame and tab bookmarks."
   (setq bufferlo--active-sets nil))
 
@@ -2955,7 +2955,7 @@ This does not close associated active frame and tab bookmarks."
         names))
 
 (defun bufferlo-set-clear-interactive ()
-  "Clear the specified bookmark sets.
+  "Clear the specified `bookmark-sets'.
 This does not close its associated bookmarks or kill their buffers."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
@@ -2964,7 +2964,7 @@ This does not close its associated bookmarks or kill their buffers."
     (bufferlo--set-clear comps)))
 
 (defun bufferlo-set-close-interactive ()
-  "Close the specified bookmark sets.
+  "Close the specified `bookmark-sets'.
 This closes their associated bookmarks and kills their buffers."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
@@ -2984,6 +2984,7 @@ This closes their associated bookmarks and kills their buffers."
   "Major mode for bufferlo set list.")
 
 (defun bufferlo--set-list-raise-bookmark-mouse (event)
+  "Handle mouse EVENT."
   (interactive "e")
   (let* ((pos (event-start event))
          (bname (get-text-property (posn-point pos) 'bookmark-name)))
@@ -2991,6 +2992,7 @@ This closes their associated bookmarks and kills their buffers."
     (bufferlo--bookmark-raise-by-name bname)))
 
 (defun bufferlo--set-list-raise-bookmark-kb ()
+  "Handle keyboard event."
   (interactive)
   (let ((bname (get-text-property (point) 'bookmark-name)))
     (quit-window)
@@ -2999,7 +3001,7 @@ This closes their associated bookmarks and kills their buffers."
 (defconst bufferlo--set-list-buffer-name " *bufferlo set list*")
 
 (defun bufferlo-set-list-interactive ()
-  "Enumerate the bookmarks in active bookmark sets."
+  "Enumerate the bookmarks in active `bookmark-sets'."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
          (comps (bufferlo--bookmark-completing-read "Select sets to enumerate: "
@@ -3205,9 +3207,9 @@ This reuses the current tab even if
 
 (defun bufferlo--bookmark-frame-save (name &optional no-overwrite no-message msg)
   "Save the current frame as a bookmark.
-NAME is the bookmark's name. If NO-OVERWRITE is non-nil, record
-the new bookmark without throwing away the old one. If NO-MESSAGE
-is non-nil, inhibit the save status message. If MSG is non-nil,
+NAME is the bookmark's name.  If NO-OVERWRITE is non-nil, record
+the new bookmark without throwing away the old one.  If NO-MESSAGE
+is non-nil, inhibit the save status message.  If MSG is non-nil,
 it is added to the save message."
   (bookmark-store name (bufferlo--bookmark-set-location
                         (bufferlo--bookmark-frame-make))
@@ -3218,18 +3220,18 @@ it is added to the save message."
 
 (defun bufferlo-bookmark-frame-save (name &optional no-overwrite no-message)
   "Save the current frame as a bookmark.
-NAME is the bookmark's name. If NO-OVERWRITE is non-nil, record
-the new bookmark without throwing away the old one. If NO-MESSAGE
+NAME is the bookmark's name.  If NO-OVERWRITE is non-nil, record
+the new bookmark without throwing away the old one.  If NO-MESSAGE
 is non-nil, inhibit the save status message.
 
 This function persists the current frame's state: The resulting bookmark
 stores the frame's window configurations, active tabs, and the local
-buffer lists those tabs. In addition, it saves the bookmark state (not
+buffer lists those tabs.  In addition, it saves the bookmark state (not
 the contents) of the bookmarkable buffers for each tab.
 
 Use `bufferlo-bookmark-tab-in-bookmarked-frame-policy' to
 influence how this function handles setting a frame bookmark in
-the presence of bookmarked tabs. Using both together is allowed,
+the presence of bookmarked tabs.  Using both together is allowed,
 but is not recommended."
   (interactive
    (list (completing-read
@@ -3528,7 +3530,7 @@ TAB is the tab being closed.  _ONLY is for compatibility with the hook."
 (defun bufferlo--bookmarks-save-at-emacs-exit ()
   "Save bufferlo bookmarks at Emacs exit.
 This honors `bufferlo-bookmarks-save-at-emacs-exit' by predicate or
-\\='all. Intended to be invoked via `kill-emacs-hook'."
+\\='all.  Intended to be invoked via `kill-emacs-hook'."
   (bufferlo--bookmarks-auto-save-timer-maybe-cancel)
   (let ((bufferlo-bookmarks-save-predicate-functions
          (if (eq bufferlo-bookmarks-save-at-emacs-exit 'all)

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2640,7 +2640,7 @@ throwing away the old one."
     (bufferlo--set-save bookmark-name comps abms no-overwrite)))
 
 (defun bufferlo-set-save-current-interactive ()
-  "Save active constituents in selected bookmark-sets."
+  "Save active constituents in selected bookmark sets."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
          (comps (bufferlo--bookmark-completing-read "Select sets to save: " candidates)))
@@ -2663,7 +2663,7 @@ throwing away the old one."
     (call-interactively 'bufferlo-bookmarks-load-interactive)))
 
 (defun bufferlo--set-clear-all ()
-  "Clear all active bookmark-sets.
+  "Clear all active bookmark sets.
 This does not close active frame and tab bookmarks."
   (setq bufferlo--active-sets nil))
 
@@ -2676,7 +2676,7 @@ This does not close associated active frame and tab bookmarks."
         names))
 
 (defun bufferlo-set-clear-interactive ()
-  "Clear the specified bookmark-sets.
+  "Clear the specified bookmark sets.
 This does not close its associated bookmarks or kill their
 buffers."
   (interactive)
@@ -2685,7 +2685,7 @@ buffers."
     (bufferlo--set-clear comps)))
 
 (defun bufferlo-set-close-interactive ()
-  "Close the specified bookmark-sets.
+  "Close the specified bookmark sets.
 This closes their associated bookmarks and kills their buffers."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
@@ -3439,7 +3439,7 @@ Save the current bufferlo frame bookmark or tab bookmark,
 prioritizing frame bookmarks over tab bookmarks, should both
 exist.
 
-Unlike, `bufferlo-bookmark-frame-save-current' and
+Unlike `bufferlo-bookmark-frame-save-current' and
 `bufferlo-bookmark-tab-save-current', this does not prompt to
 save a new bookmark."
   (interactive)
@@ -3457,7 +3457,7 @@ Load the current bufferlo frame bookmark or tab bookmark,
 prioritizing frame bookmarks over tab bookmarks, should both
 exist.
 
-Unlike, `bufferlo-bookmark-frame-load-current' and
+Unlike `bufferlo-bookmark-frame-load-current' and
 `bufferlo-bookmark-tab-load-current', this does not prompt to
 load a new bookmark."
   (interactive)

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2488,7 +2488,6 @@ Geometry set for FRAME or the current frame, if nil."
     (when (and .left .top .width .height) ; defensive in case geometry stored from a tty
       (let ((frame-resize-pixelwise t)
             (frame-inhibit-implied-resize t))
-        (make-frame-invisible frame)
         (set-frame-position frame .left .top)
         (sleep-for bufferlo-frame-sleep-for)
         ;; Clamp to restore frames larger than the current display size.
@@ -2496,8 +2495,7 @@ Geometry set for FRAME or the current frame, if nil."
                         (min .width (display-pixel-width))
                         (min .height (display-pixel-height))
                         'pixelwise)
-        (sleep-for bufferlo-frame-sleep-for)
-        (make-frame-visible frame)))))
+        (sleep-for bufferlo-frame-sleep-for)))))
 
 (defvar bufferlo--active-sets nil
   "Global active bufferlo sets.

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -3686,13 +3686,13 @@ bookmarks, double for bookmarks, triple for bookmark sets."
           (apply 'bufferlo--bookmark-get-names
                  (cond
                   ((and (consp current-prefix-arg)
-                        (eq (prefix-numeric-value current-prefix-arg) 4))
+                        (= (prefix-numeric-value current-prefix-arg) 4))
                    (list #'bufferlo--bookmark-frame-handler))
                   ((and (consp current-prefix-arg)
-                        (eq (prefix-numeric-value current-prefix-arg) 16))
+                        (= (prefix-numeric-value current-prefix-arg) 16))
                    (list #'bufferlo--bookmark-tab-handler))
                   ((and (consp current-prefix-arg)
-                        (eq (prefix-numeric-value current-prefix-arg) 64))
+                        (= (prefix-numeric-value current-prefix-arg) 64))
                    (list #'bufferlo--bookmark-set-handler))
                   (t bufferlo--bookmark-handlers))))
          (comps (bufferlo--bookmark-completing-read-multiple

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -791,6 +791,18 @@ string, FACE is the face for STR."
 (defvar bufferlo-mode-map (make-sparse-keymap)
   "`bufferlo-mode' keymap.")
 
+(defvar bufferlo--bookmark-handlers
+  (list
+   #'bufferlo--bookmark-tab-handler
+   #'bufferlo--bookmark-frame-handler
+   #'bufferlo--bookmark-set-handler)
+  "Bufferlo bookmark handlers.")
+
+(defconst bufferlo--bookmark-type-names
+  '((tbm . "B-Tab")
+    (fbm . "B-Frame")
+    (sbm . "B-Set")))
+
 ;;;###autoload
 (define-minor-mode bufferlo-mode
   "Manage frame/tab-local buffers."
@@ -2831,8 +2843,7 @@ This closes their associated bookmarks and kills their buffers."
   (interactive)
   (let* ((candidates (mapcar #'car bufferlo--active-sets))
          (comps (bufferlo--bookmark-completing-read "Select sets to enumerate: " candidates)))
-    (let* ((abms (bufferlo--active-bookmarks))
-           (abm-names (mapcar #'car abms)))
+    (let* ((abms (bufferlo--active-bookmarks)))
       (with-current-buffer (get-buffer-create bufferlo--set-list-buffer-name)
         (let ((buffer-undo-list t))
           (read-only-mode -1)
@@ -2866,18 +2877,6 @@ This closes their associated bookmarks and kills their buffers."
         (bufferlo-set-list-mode)
         (goto-char (point-min))
         (pop-to-buffer (current-buffer) nil 'norecord)))))
-
-(defvar bufferlo--bookmark-handlers
-  (list
-   #'bufferlo--bookmark-tab-handler
-   #'bufferlo--bookmark-frame-handler
-   #'bufferlo--bookmark-set-handler)
-  "Bufferlo bookmark handlers.")
-
-(defconst bufferlo--bookmark-type-names
-  '((tbm . "B-Tab")
-    (fbm . "B-Frame")
-    (sbm . "B-Set")))
 
 (defun bufferlo--bookmark-get-names (&rest handlers)
   "Get the names of all existing bookmarks for HANDLERS."

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2696,8 +2696,14 @@ throwing away the old one."
   (bufferlo--warn)
   (let* ((abms (bufferlo--active-bookmarks))
          (abm-names (mapcar #'car abms))
-         (comps (bufferlo--bookmark-completing-read (format "Add bookmark(s) to %s: " bookmark-name) abm-names)))
-    (bufferlo--set-save bookmark-name comps abms no-overwrite)))
+         (comps (bufferlo--bookmark-completing-read
+                 (format "Add bookmark(s) to %s: " bookmark-name) abm-names)))
+    (bufferlo--set-save bookmark-name comps abms no-overwrite)
+    (setq bufferlo--active-sets
+          (assoc-delete-all bookmark-name bufferlo--active-sets #'equal))
+    (push
+     `(,bookmark-name (bufferlo-bookmark-names . ,comps))
+     bufferlo--active-sets)))
 
 (defun bufferlo-set-save-current-interactive ()
   "Save active constituents in selected bookmark sets."

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1887,19 +1887,45 @@ The parameters OTHER-WINDOW-P NOSELECT SHRINK are passed to `ibuffer'."
     (ibuffer other-window-p name '((bufferlo-orphan-buffers . nil))
              noselect shrink)))
 
-(define-ibuffer-op ibuffer-do-bufferlo-remove ()
-  "Remove marked buffers from bufferlo's local buffer list."
-  (
-   :active-opstring "remove from bufferlo locals" ; prompt
-   :opstring "removed from bufferlo locals:" ; success
-   :modifier-p t
-   :dangerous t
-   :complex t
-   :after (ibuffer-update nil t)
-   )
-  (when bufferlo-mode
-    (bufferlo-remove buf)
-    t))
+(eval-when-compile
+  (if (< emacs-major-version 31)
+      (define-ibuffer-op ibuffer-do-bufferlo-remove ()
+        "Remove marked buffers from bufferlo's local buffer list."
+        (
+         :active-opstring "remove from bufferlo locals" ; prompt
+         :opstring "removed from bufferlo locals:" ; success
+         :modifier-p t
+         :dangerous t
+         :complex t
+         :after (ibuffer-update nil t)
+         )
+        (when bufferlo-mode
+          (bufferlo-remove buf)
+          t))
+
+    (defun bufferlo--ibuffer-do-bufferlo-remove-prompt (op)
+      "`ibuffer' prompt helper for OP."
+      (let ((bookmark-name (bufferlo--current-bookmark-name)))
+        (format "%s from %slocals:" op
+                (if bookmark-name
+                    (format "bufferlo bookmark \"%s\" " bookmark-name)
+                  ""))))
+
+    (define-ibuffer-op ibuffer-do-bufferlo-remove ()
+      "Remove marked buffers from bufferlo\'s local buffer list."
+      (
+       :active-opstring (lambda ()
+                        (bufferlo--ibuffer-do-bufferlo-remove-prompt "remove"))
+       :opstring (lambda ()
+                 (bufferlo--ibuffer-do-bufferlo-remove-prompt "removed"))
+       :modifier-p t
+       :dangerous t
+       :complex t
+       :after (ibuffer-update nil t)
+       )
+      (when bufferlo-mode
+        (bufferlo-remove buf)
+        t))))
 
 (when bufferlo-ibuffer-bind-keys
   (define-key ibuffer-mode-map "-" #'ibuffer-do-bufferlo-remove))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -541,9 +541,10 @@ This is controlled by `bufferlo-bookmarks-auto-save-idle-interval'.")
   (bufferlo--bookmarks-auto-save-timer-maybe-cancel)
   (when (> bufferlo-bookmarks-auto-save-idle-interval 0)
     (setq bufferlo--bookmarks-auto-save-timer
-          (run-with-timer
+          (run-with-idle-timer
            bufferlo-bookmarks-auto-save-idle-interval
-           nil #'bufferlo--bookmarks-save-timer-cb))))
+           bufferlo-bookmarks-auto-save-idle-interval
+           #'bufferlo-bookmarks-save))))
 
 (defcustom bufferlo-bookmarks-auto-save-idle-interval 0
   "Save bufferlo bookmarks when Emacs has been idle this many seconds.
@@ -3129,15 +3130,6 @@ Specify NO-MESSAGE to inhibit the bookmark save status message."
       (when (and (not no-message)
                  (memq bufferlo-bookmarks-auto-save-messages (list 'notsaved t)))
         (message "No bufferlo bookmarks saved."))))))
-
-(defun bufferlo--bookmarks-save-timer-cb ()
-  "Save active bufferlo bookmarks per an optional idle timer.
-`bufferlo-bookmarks-auto-save-idle-interval' is treated as a
-one-shot timer to prevent reentrancy."
-  (if (current-idle-time)
-      (bufferlo-bookmarks-save)
-    (run-with-idle-timer 0.1 nil #'bufferlo-bookmarks-save))
-  (bufferlo--bookmarks-auto-save-timer-maybe-start))
 
 (defun bufferlo-bookmarks-save (&optional all)
   "Save active bufferlo bookmarks.

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2456,7 +2456,8 @@ Geometry set for FRAME or the current frame, if nil."
                                        (top . ,.top)))
       (sit-for 0 t)
       ;; Clamp frame size restored from a larger display
-      (set-frame-size nil
+      (set-frame-parameter frame 'fullscreen nil)
+      (set-frame-size frame
                       (min .width (display-pixel-width))
                       (min .height (display-pixel-height))
                       'pixelwise)

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1343,7 +1343,10 @@ the advised functions.  Honors `bufferlo-bookmark-tab-duplicate-policy'."
     (apply oldfn args))
   (when-let* ((current-tab (bufferlo--current-tab))
               (bookmark-name (alist-get 'bufferlo-bookmark-tab-name current-tab))
-              (abm (assoc bookmark-name (bufferlo--active-bookmarks))))
+              (this+at-least-one-other
+               (when (> (seq-count (lambda (x) (string= bookmark-name (car x)))
+                                   (bufferlo--active-bookmarks)) 1)
+                 t)))
     (let* ((msg nil)
            (msg-append (lambda (s) (setq msg (concat msg "; " s)))))
       (catch :raise
@@ -1362,7 +1365,9 @@ the advised functions.  Honors `bufferlo-bookmark-tab-duplicate-policy'."
                    (funcall msg-append "cleared tab bookmark"))
                   ('raise
                    (tab-bar-close-tab)
-                   (bufferlo--bookmark-raise abm)
+                   ;; Find bookmark to raise; tab numbers changes when closing.
+                   (bufferlo--bookmark-raise
+                    (assoc bookmark-name (bufferlo--active-bookmarks)))
                    (throw :raise t)))
                 (setf (alist-get 'bufferlo-bookmark-tab-name
                                  (cdr current-tab))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2629,7 +2629,6 @@ the message after successfully restoring the bookmark."
          (bufferlo--bookmark-set-loading t))
     (if (assoc bookmark-name bufferlo--active-sets)
         (message "Bufferlo set \"%s\" is already active" bookmark-name)
-      (message "Close or clear active bufferlo bookmarks: %s" active-bookmark-names)
       (let ((tabsets-str (bookmark-prop-get bookmark-record 'bufferlo-tabsets))
             (tabsets))
         (if (not (readablep tabsets-str))

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -891,10 +891,11 @@ string, FACE is the face for STR."
         (advice-add #'tab-bar-undo-close-tab
                     :around #'bufferlo--tab-bar-undo-close-tab-advice)
         ;; Switch-tab workaround
-        (advice-add #'tab-bar-select-tab
-                    :around #'bufferlo--clear-buffer-lists-activate)
-        (advice-add #'tab-bar--tab
-                    :after #'bufferlo--clear-buffer-lists)
+        (when (< emacs-major-version 31)
+          (advice-add #'tab-bar-select-tab
+                      :around #'bufferlo--clear-buffer-lists-activate)
+          (advice-add #'tab-bar--tab
+                      :after #'bufferlo--clear-buffer-lists))
         ;; Set up bookmarks save timer
         (bufferlo--bookmarks-auto-save-timer-maybe-start)
         ;; kill-emacs-hook save bookmarks option
@@ -941,8 +942,9 @@ string, FACE is the face for STR."
     (advice-remove #'tab-bar-undo-close-tab
                    #'bufferlo--tab-bar-undo-close-tab-advice)
     ;; Switch-tab workaround
-    (advice-remove #'tab-bar-select-tab #'bufferlo--clear-buffer-lists-activate)
-    (advice-remove #'tab-bar--tab #'bufferlo--clear-buffer-lists)
+    (when (< emacs-major-version 31)
+      (advice-remove #'tab-bar-select-tab #'bufferlo--clear-buffer-lists-activate)
+      (advice-remove #'tab-bar--tab #'bufferlo--clear-buffer-lists))
     ;; Cancel bookmarks save timer
     (bufferlo--bookmarks-auto-save-timer-maybe-cancel)
     ;; kill-emacs-hook save bookmarks option

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2407,7 +2407,9 @@ Geometry set for FRAME or the current frame, if nil."
   (setq frame (or frame (selected-frame)))
   (let-alist frame-geometry
     (when (and .left .top .width .height) ; defensive in case geometry stored from a tty
-      (set-frame-position nil .left .top)
+      (modify-frame-parameters frame `((user-position . t)
+                                       (left . ,.left)
+                                       (top . ,.top)))
       (sit-for 0 t)
       ;; Clamp frame size restored from a larger display
       (set-frame-size nil

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2513,11 +2513,20 @@ When non-nil, NO-SORT uses the natural order of the CANDIDATES list."
 PROMPT is the prompt text ending with a space.
 CANDIDATES are the prompt options to select.
 When non-nil, NO-SORT uses the natural order of the CANDIDATES list."
-  (let* ((comps
+  (let* ((raw-comps
           (completing-read-multiple
            prompt
            (bufferlo--bookmark-completion-table candidates no-sort)
            nil 'require-match nil 'bufferlo-bookmark-history))
+         (comps (mapcan (lambda (raw-comp)
+                          (let ((tmp-comps
+                                 (completion-all-completions
+                                  raw-comp
+                                  candidates nil nil)))
+                            (when (cdr (last tmp-comps))
+                              (setcdr (last tmp-comps) nil))
+                            tmp-comps))
+                        raw-comps))
          (comps (seq-uniq (mapcar (lambda (x) (substring-no-properties x)) comps))))
     comps))
 

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -126,14 +126,19 @@ This is a list of regular expressions that match buffer names."
   "If non-nil, confirm before killing local or orphan buffers."
   :type 'boolean)
 
-(defcustom bufferlo-kill-modified-buffers-policy 'kill-modified
+(defcustom bufferlo-kill-modified-buffers-policy
+  'retain-modified-kill-without-file-name
   "Bufferlo behavior when killing modified or process buffers.
+
+This policy applies to all bufferlo functions that entail killing buffers,
+e.g., `bufferlo-kill-buffers', `bufferlo-kill-orphan-buffers',
+`bufferlo-tab-close-kill-buffers', `bufferlo-delete-frame-kill-buffers'.
 
 This policy is useful when `shell-mode' or `eshell-mode' buffers
 are active in a bufferlo-controlled frame or tab.
 
 nil means default Emacs behavior which may prompt. This may have
-side effects when killing frames.
+side effects.
 
 \\='retain-modified means bufferlo will leave modified buffers as
 is.

--- a/bufferlo.el
+++ b/bufferlo.el
@@ -2451,7 +2451,8 @@ Geometry set for FRAME or the current frame, if nil."
   (setq frame (or frame (selected-frame)))
   (let-alist frame-geometry
     (when (and .left .top .width .height) ; defensive in case geometry stored from a tty
-      (let ((frame-inhibit-implied-resize t))
+      (let ((frame-resize-pixelwise t)
+            (frame-inhibit-implied-resize t))
         (modify-frame-parameters frame `((fullscreen . nil) ; fullscreen via default-frame-alist when set
                                          (user-position . t)
                                          (left . ,.left)


### PR DESCRIPTION
We may also want to consider using normalized buffer names for all filtering.  For users that enable uniquify, they may find it surprising that their filter regexps will not work for both unqualified and uniquified names.