### PR TITLE
Final stretch 1.1-pre WIP.

### DIFF
--- a/README.org
+++ b/README.org
@@ -587,11 +587,11 @@ Note: 'raise is considered to act as 'clear by bookmark set loading.
 #+end_src
 #+begin_src emacs-lisp
   ;; handle buffer bookmarks that could not be restored
-  (setq bufferlo-bookmark-tab-failed-buffer-policy 'placeholder) ; placeholder buffer and buffer name; the default
+  (setq bufferlo-bookmark-tab-failed-buffer-policy nil) ; ignore; the default
+  (setq bufferlo-bookmark-tab-failed-buffer-policy 'placeholder) ; placeholder buffer and buffer name
   (setq bufferlo-bookmark-tab-failed-buffer-policy 'placeholder-orig) ; placeholder buffer with original buffer name
   (setq bufferlo-bookmark-tab-failed-buffer-policy "*scratch*") ; default to a specific buffer
   (setq bufferlo-bookmark-tab-failed-buffer-policy #'my/failed-bookmark-handler) ; function to call that returns a buffer
-  (setq bufferlo-bookmark-tab-failed-buffer-policy nil) ; ignore
 #+end_src
 
 *** Bookmark set options


### PR DESCRIPTION
- Correct 'bufferlo-kill-buffers' and 'bufferlo-kill-orphan-buffers' 'internal-too' and hidden buffer filtering (the logic had been inverted).

- Refine 'bufferlo--bookmark-tab-handler' terminology from success/failure to restored/skipped.

- Improve bookmark auto save handling to avoid timer reentrancy issues and improve handling bookmark.el prompts which should also address minibuffer prompts changing focus.

- Remove arguments from 'bufferlo--bookmark-tab-make' and 'bufferlo--bookmark-frame-make' (that code was unused).

- Improve 'bufferlo--kill-buffer-safely' to avoid spurious window creation by kill-buffer when the buffer is on the sole window of a frame.

- Refine 'bufferlo--close-active-bookmarks' tab-tag logic to tag only tabs on bookmarked tabs.

- README corrected default for 'bufferlo-bookmark-tab-failed-buffer-policy'.

- General typos, docstring improvement, and some formatting improvements.

- flymake/byte compiler noise.