### PR TITLE
Fix consult integration code example

### DIFF
--- a/README.org
+++ b/README.org
@@ -948,7 +948,7 @@ keys interfering with one another.
 
 This is an example of the first configuration method:
 #+begin_src emacs-lisp
-  (defvar my:bufferlo-consult--source-local-buffer
+  (defvar my:bufferlo-consult--source-local-buffers
     (list :name "Bufferlo Local Buffers"
           :narrow   ?l
           :category 'buffer
@@ -962,7 +962,7 @@ This is an example of the first configuration method:
                                 :as #'buffer-name)))
     "Local Bufferlo buffer candidate source for `consult-buffer'.")
 
-  (defvar my:bufferlo-consult--source-buffer
+  (defvar my:bufferlo-consult--source-other-buffers
     (list :name "Bufferlo Other Buffers"
           :narrow   ?b
           :category 'buffer


### PR DESCRIPTION
The consult integration code example has a small mistake. It uses different variable names for `add-to-list` than defined previously in the snippet.