### PR TITLE
Support Emacs 31 'bookmark-after-load-file-hook'

### DIFF
--- a/bufferlo.el
+++ b/bufferlo.el
@@ -1120,7 +1120,9 @@ string, FACE is the face for STR."
                   #'bufferlo-bookmark--tab-save-on-close)
         (add-hook 'delete-frame-functions
                   #'bufferlo-bookmark--frame-save-on-delete)
-        ;; bookmark advice
+        ;; bookmark hook and advice
+        (add-hook 'bookmark-after-load-file-hook
+                  #'bufferlo--bookmark-after-load-file-hook)
         (advice-add #'bookmark--jump-via :around #'bufferlo--bookmark--jump-via-advice)
         (advice-add #'bookmark-rename :around #'bufferlo--bookmark-rename-advice)
         (advice-add #'bookmark-delete :around #'bufferlo--bookmark-delete-advice)
@@ -1168,7 +1170,9 @@ string, FACE is the face for STR."
                  #'bufferlo-bookmark--tab-save-on-close)
     (remove-hook 'delete-frame-functions
                  #'bufferlo-bookmark--frame-save-on-delete)
-    ;; bookmark advice
+    ;; bookmark hook and advice
+    (remove-hook 'bookmark-after-load-file-hook
+                 #'bufferlo--bookmark-after-load-file-hook)
     (advice-remove #'bookmark--jump-via #'bufferlo--bookmark--jump-via-advice)
     (advice-remove #'bookmark-rename #'bufferlo--bookmark-rename-advice)
     (advice-remove #'bookmark-delete #'bufferlo--bookmark-delete-advice)))
@@ -4997,7 +5001,15 @@ exist."
         (bufferlo-tab-close-kill-buffers)
       (message "No active bufferlo frame or tab bookmark to close."))))
 
-;;; bookmark advisories
+;;; bookmark hook and advice
+
+(defun bufferlo--bookmark-after-load-file-hook ()
+  "Scan the loaded bookmarks list for missing active bufferlo bookmarks."
+  (let ((alist-bookmarks (bufferlo--bookmark-get-names)))
+    (dolist (bookmark (bufferlo--active-bookmarks))
+      (unless (member (car bookmark) alist-bookmarks)
+        (warn "Active bufferlo bookmark `%s' not present in loaded bookmarks"
+              (car bookmark))))))
 
 ;; (defun bookmark-set (&optional name no-overwrite)
 ;; (defun bookmark-set-no-overwrite (&optional name push-bookmark)


### PR DESCRIPTION
Warn when an active bufferlo bookmark is not present in a refreshed bookmark list.

* bufferlo.el (bufferlo-mode): Add/remove hook.
(bufferlo--bookmark-after-load-file-hook): Hook implementation.

Satisfies https://github.com/florommel/bufferlo/issues/60